### PR TITLE
Draft English APP-A prompt templates appendix

### DIFF
--- a/manuscript-en/STATUS.md
+++ b/manuscript-en/STATUS.md
@@ -14,7 +14,7 @@
 | CH10 | `manuscript/part-03-harness/ch10-verification-harness.md` | `manuscript-en/part-03-harness/ch10-verification-harness.md` | scaffolded |
 | CH11 | `manuscript/part-03-harness/ch11-long-running-and-multi-agent.md` | `manuscript-en/part-03-harness/ch11-long-running-and-multi-agent.md` | scaffolded |
 | CH12 | `manuscript/part-03-harness/ch12-operating-model.md` | `manuscript-en/part-03-harness/ch12-operating-model.md` | scaffolded |
-| APP-A | `manuscript/appendices/app-a-Prompt-テンプレート集.md` | `manuscript-en/appendices/app-a-prompt-templates.md` | scaffolded |
+| APP-A | `manuscript/appendices/app-a-Prompt-テンプレート集.md` | `manuscript-en/appendices/app-a-prompt-templates.md` | drafted |
 | APP-B | `manuscript/appendices/app-b-Context-テンプレート集.md` | `manuscript-en/appendices/app-b-context-templates.md` | scaffolded |
 | APP-C | `manuscript/appendices/app-c-Harness-テンプレート集.md` | `manuscript-en/appendices/app-c-harness-templates.md` | scaffolded |
 | APP-D | `manuscript/appendices/app-d-用語集.md` | `manuscript-en/appendices/app-d-glossary.md` | drafted |

--- a/manuscript-en/appendices/app-a-prompt-templates.md
+++ b/manuscript-en/appendices/app-a-prompt-templates.md
@@ -1,20 +1,108 @@
 # Prompt Templates
 
-This appendix mirrors the Japanese appendix that explains the reusable prompt-side templates used across the book.
-
 ## Purpose
-Provide the English appendix structure for prompt templates while keeping the same artifact references as the Japanese edition.
+
+Prompt Engineering in this book is not the search for clever wording. It is the work of fixing the inputs, constraints, completion criteria, and output format that let a single task complete reliably. This appendix collects the smallest reusable templates that support that job.
+
+Prompt templates are used to define the work boundary before implementation or review begins. The goal is not to write a long explanation. The goal is to remove ambiguity and cut the task into a unit that can be verified.
 
 ## Included Artifacts
+
 - `templates/prompt-contract.md`
 - `templates/prompt-rubric.md`
+- `templates/en/prompt-contract.md`
+- `templates/en/prompt-rubric.md`
+
+## 1. Prompt Contract Template
+
+`templates/prompt-contract.md` defines the book's canonical Prompt Contract shape, and `templates/en/prompt-contract.md` provides the English counterpart for English-manuscript use. As CH02 explains, the important thing is not only to say what the agent should do. The contract must also fix which inputs it may use, which actions it must not take, and what counts as done.
+
+Each section has a distinct job.
+
+- `Objective`: fix the target result in one sentence
+- `Inputs`: list the issue, task brief, spec, tests, and verify commands that the worker must read
+- `Constraints`: limit scope, preserve public contracts, and name artifacts that must be updated together
+- `Forbidden Actions`: stop risky guesses and unrelated work before execution starts
+- `Missing Information Policy`: separate the conditions that should block execution from the conditions that allow a documented assumption
+- `Completion Criteria`: define done in words that can be verified
+- `Output Format`: fix the final report headings so review is faster and more consistent
+
+In practice, `prompts/bugfix-contract.md` and `prompts/feature-contract.md` are the worked examples. The `Objective` and `Completion Criteria` differ by task type, but the contract structure stays stable. First fix the structure, then fill only the task-specific differences.
+
+A minimal fill looks like this:
+
+```md
+## Objective
+Identify the root cause of the target bug and fix it with the smallest safe change.
+
+## Inputs
+- issue or task brief
+- repro steps
+- related tests
+- verify command
+
+## Constraints
+- do not change the public interface
+- add or update the failing test first
+
+## Forbidden Actions
+- do not mix unrelated refactors
+- do not skip verify
+
+## Completion Criteria
+- a test fails before the fix and passes after the fix
+- the required verify command passes
+```
+
+When you write a Prompt Contract, define both of these boundaries:
+
+- what should stop the agent before execution starts
+- what lets the reviewer call the work complete after execution ends
+
+A prompt that defines only one side may still read well, but it is weak as an operational contract.
+
+## 2. Prompt Rubric Template
+
+`templates/prompt-rubric.md` defines the canonical rubric shape, and `templates/en/prompt-rubric.md` provides the English counterpart. The rubric exists so Prompt Engineering does not collapse into preference or folklore. As CH04 argues, prompt quality must be evaluated, not assumed.
+
+At minimum, the rubric should cover these criteria.
+
+- `Goal clarity`
+- `Input completeness`
+- `Constraint clarity`
+- `Forbidden action clarity`
+- `Verifiability`
+- `Output format specificity`
+
+In practical use, a three-point scale is usually enough.
+
+- `0`: fail
+- `1`: partial
+- `2`: pass
+
+The point is not fine-grained scoring. The point is to explain what improved between one prompt version and the next. Without a rubric, teams tend to preserve prompts that happened to look good once and miss the next regression.
+
+## 3. How to Use Them in Practice
+
+The Prompt Contract and the Prompt Rubric solve different problems.
+
+- the Prompt Contract is the execution artifact
+- the Prompt Rubric is the evaluation artifact
+
+The recommended order is contract first, rubric second. If the rubric comes first, teams often score prompts before they have fixed which single task they are trying to stabilize.
+
+Appendix A stays within Prompt Engineering. Repo-wide reading order, task history, and session carry-over belong to Context Engineering and later appendices. Within this appendix, focus on the prompt artifact that stabilizes one task.
 
 ## Parity Notes
+
 - Japanese source: `manuscript/appendices/app-a-Prompt-テンプレート集.md`
-- Publication target: match the Japanese appendix's explanation depth and practical usage notes.
+- Publication target: preserve the Japanese appendix's boundary between Prompt Contract and Prompt Rubric, its practical minimal examples, and its Prompt-only scope boundary.
 
 ## Referenced Artifacts
+
 - `templates/prompt-contract.md`
 - `templates/prompt-rubric.md`
+- `templates/en/prompt-contract.md`
+- `templates/en/prompt-rubric.md`
 - `prompts/bugfix-contract.md`
 - `prompts/feature-contract.md`

--- a/templates/en/README.md
+++ b/templates/en/README.md
@@ -7,8 +7,9 @@ This directory reserves the English counterparts of reusable templates reference
 - Establish the directory contract for future English templates
 - Keep the path stable for appendix and parity work
 - Avoid mixing English template growth with Japanese template maintenance
+- Maintain English prompt-template counterparts for Appendix A
 
 ## Out of Scope in EN-01
 
-- Full English translations of template files
+- English translations of context and harness templates beyond the prompt-template set
 - Changes to the Japanese template contract

--- a/templates/en/prompt-contract.md
+++ b/templates/en/prompt-contract.md
@@ -1,0 +1,23 @@
+# Prompt Contract Template
+
+## Objective
+- State the target result in one sentence.
+
+## Inputs
+- List the required inputs such as the issue, task brief, spec, tests, and verify commands.
+
+## Constraints
+- Record the public contracts, scope limits, and required co-updated artifacts that must be preserved.
+
+## Forbidden Actions
+- Block risky guesses, unrelated refactors, and any work that should not be mixed into this task.
+
+## Missing Information Policy
+- State what missing input must stop execution.
+- State what assumptions may be made and how they must be recorded in the final report.
+
+## Completion Criteria
+- Write the conditions that let a reviewer verify the task is complete.
+
+## Output Format
+- Fix the headings used in the final report.

--- a/templates/en/prompt-rubric.md
+++ b/templates/en/prompt-rubric.md
@@ -1,0 +1,23 @@
+# Prompt Rubric Template
+
+## Purpose
+- State which prompt artifact is being evaluated and what it is being compared against.
+
+## Scale
+- 0: fail
+- 1: partial
+- 2: pass
+
+## Criteria
+- Goal clarity
+- Input completeness
+- Constraint clarity
+- Forbidden action clarity
+- Verifiability
+- Output format specificity
+
+## Minimum Bar
+- State which failed criteria make the prompt unacceptable.
+
+## Notes
+- Record case-specific observations or follow-up questions.


### PR DESCRIPTION
## Summary
- draft the full English version of Appendix A
- add English prompt-template counterparts under `templates/en/`
- update the English manuscript status and template-scope note

## Verification
- `./scripts/verify-book.sh`

Closes #76
