### PR TITLE
Add English backmatter and source-note parity

### DIFF
--- a/manuscript-en/README.md
+++ b/manuscript-en/README.md
@@ -18,6 +18,7 @@ manuscript-en/
   part-01-prompt/  # Chapters 2-4
   part-02-context/ # Chapters 5-8
   part-03-harness/ # Chapters 9-12
+  backmatter/      # English source notes, reading guide, index seed, figure/table policy
   appendices/      # Appendix A-D
 ```
 

--- a/manuscript-en/backmatter/00-source-notes.md
+++ b/manuscript-en/backmatter/00-source-notes.md
@@ -1,0 +1,82 @@
+# Source Notes
+
+This backmatter gathers the chapter-end `Source Notes / Further Reading` sections so readers can quickly re-find what counts as the source of truth and where to read next. It is not a replacement for exhaustive footnotes or a full bibliography.
+
+## What This Backmatter Does
+
+- Shows which source types should anchor the book's claims: repo artifacts, official docs, and durable engineering references
+- Collects next-step reading paths that do not fit cleanly inside each chapter
+- Keeps a clear division of labor with the glossary: the glossary defines terms, while source notes define trust and navigation
+
+## Source Policy
+
+Keep the trust order fixed.
+
+1. Canonical artifacts inside this repo
+2. Official docs for the tool, platform, or library in use
+3. Durable books, handbooks, and public design notes
+4. Blog posts, conference talks, and social media
+
+If that order drifts, the manuscript becomes too dependent on fashion, screenshots, or one-off success stories. This is especially important around AI agents, where behavior and product surfaces change quickly. Prefer the official behavior of the tool you are actually using over generalized commentary.
+
+## Chapter-by-Chapter Source Notes
+
+### CH01 Where AI Agents Fail
+
+- Start with `sample-repo/README.md`, `sample-repo/docs/domain-overview.md`, and `sample-repo/docs/seed-issues.md`. The failure model matters only when it stays connected to the recurring cases.
+- If you add external sources, prefer official docs for the coding agent, CI, and issue tracker you actually use, plus local postmortems. Do not build the failure model from demos alone.
+
+### CH02 Design Prompts as Contracts
+
+- Start with `prompts/bugfix-contract.md`, `prompts/feature-contract.md`, and `checklists/prompt-contract-review.md`. In this book, a Prompt Contract is a repo artifact rather than a conversational trick.
+- If you add external sources, prefer official prompting, structured-output, and tool-use docs for the model you are using. Do not treat generic prompt collections as the source of truth.
+
+### CH03 Use ChatGPT to Shape Requirements and Design
+
+- Start with `sample-repo/docs/product-specs/ticket-search.md`, `sample-repo/docs/design-docs/ticket-search-adr.md`, and `sample-repo/docs/acceptance-criteria/ticket-search.md`. Exploratory dialogue does not become the implementation contract by itself.
+- If you add external sources, prefer the product-spec, acceptance-criteria, and ADR templates your organization actually uses. For requirement shaping, decision trace matters more than fluent wording.
+
+### CH04 Evaluate Prompts
+
+- Start with `evals/prompt-contract-cases.json`, `evals/rubrics/feature-spec.json`, and `scripts/run-prompt-evals.py`. Prompt quality should be read through reusable cases and rubrics, not through vibes.
+- If you add external sources, prefer official docs for the model or eval framework you are using. Screenshots of one-off prompt comparisons are not stable regression evidence.
+
+### CH05 Foundations of Context Engineering
+
+- Start with `docs/context-model.md`, `docs/context-budget.md`, and `docs/context-risk-register.md`. Context Engineering is not about adding more text. It is about managing lifespan, authority, and contamination risk.
+- If you add external sources, prefer official docs for context windows, instruction layering, and workspace access in the tools you use. A pile of long prompts is not a context design method.
+
+### CH06 Design Repo Context
+
+- Start with `AGENTS.md`, `manuscript/AGENTS.md`, `sample-repo/AGENTS.md`, `sample-repo/docs/repo-map.md`, `sample-repo/docs/architecture.md`, and `sample-repo/docs/coding-standards.md`. Read the repo map as the index and the architecture doc as the design rationale.
+- If you add external sources, prefer official docs for the VCS, CI, and package manager you use. Repo responsibility boundaries are easier to judge from the concrete repo than from abstractions.
+
+### CH07 Task Context and Session Memory
+
+- Start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, `docs/session-memory-policy.md`, and `.github/ISSUE_TEMPLATE/task.yml`. Read the restart packet together with the latest verification result.
+- If you add external sources, prefer your issue-tracker, handoff, and change-log policies. Do not treat stale chat transcripts as the source of truth for session memory.
+
+### CH08 Reuse Skills and Context Packs
+
+- Start with `.agents/skills/draft-chapter/SKILL.md`, `.agents/skills/review-chapter/SKILL.md`, `sample-repo/.agents/skills/issue-to-plan/SKILL.md`, `sample-repo/.agents/skills/verification/SKILL.md`, and `sample-repo/context-packs/ticket-search.md`. Read a skill as a reusable workflow contract and a context pack as a task-specific minimum input.
+- If you add external sources, prefer official skill or instruction docs for the runtime you are using. Do not explain reuse only by naming a framework.
+
+### CH09 Foundations of Harness Engineering
+
+- Start with `scripts/init.sh`, `scripts/verify-sample.sh`, `sample-repo/docs/harness/single-agent-runbook.md`, `sample-repo/docs/harness/permission-policy.md`, and `sample-repo/docs/harness/done-criteria.md`. A single-agent harness is a bundle of start conditions and exit conditions, not a prompt variant.
+- If you add external sources, prefer official docs for the shell, CI runner, and permission model you use. Authority boundaries should come from the execution environment, not from intuition.
+
+### CH10 Build a Verification Harness
+
+- Start with `.github/workflows/verify.yml`, `checklists/verification.md`, `sample-repo/tests/test_ticket_search.py`, and `artifacts/evidence/README.md`. Read the verification harness as one flow across tests, CI, evidence, and approval.
+- If you add external sources, prefer official docs for the test framework, CI system, and coverage tooling you use. A green screenshot alone is not reproducible evidence.
+
+### CH11 Long-running Tasks and Multi-agent Work
+
+- Start with `sample-repo/docs/harness/feature-list.md`, `sample-repo/docs/harness/restart-protocol.md`, `sample-repo/docs/harness/multi-agent-playbook.md`, and `sample-repo/tasks/FEATURE-002-plan.md`. Multi-agent work becomes safe only after the role split and restart packet are concrete.
+- If you add external sources, prefer official docs for the orchestration tool or task queue you use. Do not separate the parallelization discussion from write scope and handoff artifacts.
+
+### CH12 Operating Model and Organizational Adoption
+
+- Start with `docs/operating-model.md`, `docs/metrics.md`, `checklists/repo-hygiene.md`, and `.github/pull_request_template.md`. Read the operating model through roles, review budget, cadence, and cleanup rather than through model comparisons alone.
+- If you add external sources, prefer official documents for your organization's review policy, release policy, and metric definitions. Do not reduce adoption decisions to model benchmarks.

--- a/manuscript-en/backmatter/01-reading-guide.md
+++ b/manuscript-en/backmatter/01-reading-guide.md
@@ -1,0 +1,43 @@
+# Reading Guide
+
+This reading guide is for the point after a reader has finished the chapter prose and repo artifacts and wants durable sources that deepen understanding. It favors reuse value over exhaustiveness.
+
+## How to Use This Guide
+
+- Return first to the manuscript and repo artifacts in this book
+- Then read the official docs for the tool or platform you actually use
+- Use books and handbooks to strengthen organizational judgment, not to replace local artifacts
+- The goal is not academic completeness. The goal is durable next-step reading
+
+## Prompts and Requirements Shaping
+
+| Source | What It Strengthens | Related Chapters |
+|---|---|---|
+| Official prompting guide for the model in use | Prompt Contracts, constraint design, tool-use assumptions | CH02, CH04 |
+| Official eval docs for the model in use | Case design, rubrics, version comparison | CH04 |
+| Michael Nygard, *Architecture Decision Records* | Writing short and durable design decisions | CH03 |
+| Internal product-spec and acceptance-criteria templates | The threshold for turning exploratory dialogue into implementation-ready artifacts | CH03 |
+
+## Context and Repo Design
+
+| Source | What It Strengthens | Related Chapters |
+|---|---|---|
+| Official docs for the agent runtime in use | Instruction layering, workspace access, session handling | CH05, CH06, CH07, CH08 |
+| Internal repo maps, architecture docs, and coding standards | Canonical repo context and clearer ownership | CH06 |
+| Internal handoff, incident, and change-log rules | Session memory, restart packets, and resume discipline | CH07, CH11 |
+
+## Verification, Reliability, and Operations
+
+| Source | What It Strengthens | Related Chapters |
+|---|---|---|
+| Titus Winters, Tom Manshreck, Hyrum Wright, *Software Engineering at Google* | Change management, review discipline, testing, and documentation practice | CH03, CH06, CH10, CH12 |
+| Betsy Beyer et al., *Site Reliability Engineering* | Reliability, operational responsibility, and service thinking | CH09, CH10, CH12 |
+| Betsy Beyer et al., *The Site Reliability Workbook* | Checklists, runbooks, and implementation-focused operations design | CH09, CH10, CH11, CH12 |
+| Nicole Forsgren, Jez Humble, Gene Kim, *Accelerate* | Metrics, throughput, and operational improvement | CH10, CH12 |
+
+## How to Choose Which Source to Read Next
+
+- If a prompt question is unclear, return first to official docs and local eval artifacts
+- If a context question is unclear, return first to repo artifacts and ownership documents
+- If a harness question is unclear, return first to verify, evidence, and review policy
+- Books and handbooks should reinforce judgment, not replace local artifacts

--- a/manuscript-en/backmatter/02-index-seed.md
+++ b/manuscript-en/backmatter/02-index-seed.md
@@ -1,0 +1,46 @@
+# Index Seed
+
+This file is the seed for the production index. At this stage it fixes the main chapter and primary artifact for each entry instead of page numbers.
+
+## How to Use This Seed
+
+- Use the glossary to look up definitions
+- Use this index seed to find the chapter and artifact to revisit
+- During production, add page numbers and see / see also links from this seed
+
+## Index Seed
+
+| Entry | Return-to Chapter | Primary Artifact / Supporting Reference |
+|---|---|---|
+| acceptance criteria | CH03, CH10 | `sample-repo/docs/acceptance-criteria/ticket-search.md`, `sample-repo/tests/test_ticket_search.py` |
+| ADR | CH03 | `sample-repo/docs/design-docs/ticket-search-adr.md` |
+| AGENTS.md | CH06 | `AGENTS.md`, `manuscript/AGENTS.md`, `sample-repo/AGENTS.md` |
+| AI agent | CH01, CH12 | `docs/en/glossary.md`, `docs/operating-model.md` |
+| artifact | CH01, Appendix D | `docs/en/glossary.md` |
+| bad / good example | CH01-CH12 | Each chapter's bad / corrected example section |
+| ChatGPT | CH03 | `docs/en/glossary.md` |
+| coding agent | CH01, CH12 | `docs/en/glossary.md`, `docs/operating-model.md` |
+| Codex CLI | CH06, CH12 | `docs/en/glossary.md`, `.github/pull_request_template.md` |
+| context pack | CH08 | `sample-repo/context-packs/ticket-search.md` |
+| Context Engineering | CH01, CH05 | `docs/context-model.md` |
+| done criteria | CH09 | `sample-repo/docs/harness/done-criteria.md` |
+| evidence bundle | CH10 | `artifacts/evidence/README.md` |
+| feature list | CH11 | `sample-repo/docs/harness/feature-list.md` |
+| Harness Engineering | CH01, CH09 | `sample-repo/docs/harness/single-agent-runbook.md` |
+| operating model | CH12 | `docs/operating-model.md` |
+| permission policy | CH09 | `sample-repo/docs/harness/permission-policy.md` |
+| Progress Note | CH07 | `sample-repo/tasks/FEATURE-001-progress.md` |
+| Prompt Contract | CH02 | `prompts/bugfix-contract.md`, `prompts/feature-contract.md` |
+| Prompt Engineering | CH01, CH02 | `checklists/prompt-contract-review.md` |
+| repo context | CH06 | `sample-repo/docs/repo-map.md`, `sample-repo/docs/architecture.md` |
+| repo hygiene | CH12 | `checklists/repo-hygiene.md` |
+| restart packet | CH11 | `sample-repo/docs/harness/restart-protocol.md` |
+| review budget | CH12 | `docs/operating-model.md`, `docs/metrics.md` |
+| rubrics | CH04 | `evals/rubrics/feature-spec.json` |
+| sample-repo | CH01 | `sample-repo/README.md`, `sample-repo/docs/domain-overview.md` |
+| session memory | CH07 | `docs/session-memory-policy.md` |
+| skill | CH08 | `.agents/skills/draft-chapter/SKILL.md`, `sample-repo/.agents/skills/verification/SKILL.md` |
+| source notes | This backmatter | `manuscript-en/backmatter/00-source-notes.md` |
+| task brief | CH07 | `sample-repo/tasks/FEATURE-001-brief.md` |
+| verification harness | CH10 | `.github/workflows/verify.yml`, `checklists/verification.md` |
+| work package | CH11, CH12 | `sample-repo/tasks/FEATURE-002-plan.md`, `docs/operating-model.md` |

--- a/manuscript-en/backmatter/03-figure-table-list-policy.md
+++ b/manuscript-en/backmatter/03-figure-table-list-policy.md
@@ -1,0 +1,46 @@
+# Figure and Table Listing Policy
+
+This file is the source of truth for building the figure list and table list in ebook and print backmatter. The figure sources live under `manuscript/figures/`, and the table sources live in each chapter's Markdown tables.
+
+## Role
+
+- Help readers re-find figures and tables after they finish the book
+- Preserve a stable seed before production adds figure numbers, table numbers, and page references
+- Keep the figure plan, chapter prose, and production output aligned
+
+## Figure List Policy
+
+- Treat `manuscript/figures/figure-plan.md` as the source of truth for figure ID, chapter, caption, and first mention
+- Keep each caption reader-facing so the main lesson of the figure is visible in one line
+- Preserve the rule of one figure for one main message, then swap only the production numbering later
+
+## Current Figure Seed
+
+| Figure ID | Chapter | First Mention | Source |
+|---|---|---|---|
+| `fig-01` | CH01 | The map from Prompt / Context / Harness | `manuscript/figures/fig-01-maturity-model.mmd` |
+| `fig-02` | CH05 | Persistent, task, session, and tool context | `manuscript/figures/fig-02-context-classes.mmd` |
+| `fig-03` | CH07 | The minimum input for resuming a session | `manuscript/figures/fig-03-resume-packet.mmd` |
+| `fig-04` | CH09 | The overall single-agent harness flow | `manuscript/figures/fig-04-single-agent-harness.mmd` |
+| `fig-05` | CH10 | The order of lint, typecheck, unit, and e2e | `manuscript/figures/fig-05-verification-pipeline.mmd` |
+| `fig-06` | CH11 | The split among planner, coder, and reviewer | `manuscript/figures/fig-06-long-running-multi-agent.mmd` |
+| `fig-07` | CH12 | The responsibilities that remain with humans | `manuscript/figures/fig-07-operating-model.mmd` |
+
+## Table List Policy
+
+- Include only reader-facing tables, not temporary comparison tables or list substitutes
+- Confirm production table titles by pairing the nearest heading with the table's main message
+- Until page numbers exist, keep the seed in terms of return-to chapter and nearby heading
+
+## Current Table Seed
+
+| Return-to Chapter | Nearby Heading | Table Role |
+|---|---|---|
+| CH01 | Getting one answer right is different from getting work done | Shows the difference between plausible output and completed work |
+| CH02 | Separate objective, constraints, completion criteria, and forbidden actions | Shows the Prompt Contract elements and the failures caused by missing ones |
+| CH04 | Evaluate prompts as operational artifacts | Shows the boundary among prompt, context, and harness evaluation |
+| CH07 | Task context and session memory | Shows the minimum elements required for a restart |
+| CH09 | Foundations of Harness Engineering | Compresses the flow from init to final report |
+| CH10 | Verification is a system, not a single test run | Shows the order from failing test to approval |
+| CH11 | Decide when to stay single-agent and when to split roles | Shows the branching conditions between single-agent and multi-agent work |
+| CH12 | Operate by metrics, review budget, and hygiene | Shows the measurement group for throughput, quality, and hygiene |

--- a/manuscript-en/part-00/ch01-failure-model.md
+++ b/manuscript-en/part-00/ch01-failure-model.md
@@ -136,11 +136,15 @@ Comparison points:
 - `sample-repo/docs/domain-overview.md`
 - `sample-repo/docs/seed-issues.md`
 
-## Parity Notes
-- Japanese source: `manuscript/part-00/ch01-failure-model.md`
-- This file is now a full English draft and should stay aligned with the Japanese chapter's failure model, recurring cases, and maturity-model framing.
+## Source Notes / Further Reading
+- When you need to revisit this chapter, start with `sample-repo/README.md`, `sample-repo/docs/domain-overview.md`, and `sample-repo/docs/seed-issues.md`. The failure model is useful only when it stays connected to the recurring cases.
+- For the next navigation step, see `manuscript-en/backmatter/00-source-notes.md` under `### CH01 Where AI Agents Fail` and `manuscript-en/backmatter/01-reading-guide.md` under `## Prompts and Requirements Shaping` and `## Verification, Reliability, and Operations`.
 
 ## Chapter Summary
 - AI agents fail in four recurring ways: wrong answer, forgetting, breaking things, and stopping early.
 - This book is about completing work with artifacts and verification, not producing plausible output.
 - Prompt Engineering, Context Engineering, and Harness Engineering are layered because each one addresses a different failure pattern. The next chapter starts with Prompt Engineering.
+
+## Parity Notes
+- Japanese source: `manuscript/part-00/ch01-failure-model.md`
+- This file is now a full English draft and should stay aligned with the Japanese chapter's failure model, recurring cases, and maturity-model framing.

--- a/manuscript-en/part-01-prompt/ch02-prompt-as-contract.md
+++ b/manuscript-en/part-01-prompt/ch02-prompt-as-contract.md
@@ -189,7 +189,7 @@ Comparison points:
 
 ## Source Notes / Further Reading
 - Treat `prompts/bugfix-contract.md`, `prompts/feature-contract.md`, and `checklists/prompt-contract-review.md` as the primary artifacts for this chapter. In this book, a Prompt Contract is a repo artifact, not a conversation trick.
-- For the next navigation step, see `manuscript/backmatter/00-source-notes.md` under `### CH02 プロンプトを契約として設計する` and `manuscript/backmatter/01-読書案内.md` under `## Prompt と要求定義`.
+- For the next navigation step, see `manuscript-en/backmatter/00-source-notes.md` under `### CH02 Design Prompts as Contracts` and `manuscript-en/backmatter/01-reading-guide.md` under `## Prompts and Requirements Shaping`.
 
 ## Chapter Summary
 - Prompt Engineering begins by designing prompts as execution contracts rather than vague instructions.

--- a/manuscript-en/part-01-prompt/ch03-requirements-and-design.md
+++ b/manuscript-en/part-01-prompt/ch03-requirements-and-design.md
@@ -163,7 +163,7 @@ The important point in this worked example is that ChatGPT does not directly dec
 
 ## Source Notes / Further Reading
 - When you need to revisit this chapter, treat `sample-repo/docs/product-specs/ticket-search.md`, `sample-repo/docs/design-docs/ticket-search-adr.md`, and `sample-repo/docs/acceptance-criteria/ticket-search.md` as the source of truth. Do not treat exploratory dialogue as the implementation contract.
-- For the next navigation step, see `manuscript/backmatter/00-source-notes.md` under `### CH03 ChatGPTで要件と設計を固める` and `manuscript/backmatter/01-読書案内.md` under `## Prompt と要求定義`.
+- For the next navigation step, see `manuscript-en/backmatter/00-source-notes.md` under `### CH03 Use ChatGPT to Shape Requirements and Design` and `manuscript-en/backmatter/01-reading-guide.md` under `## Prompts and Requirements Shaping`.
 
 ## Chapter Summary
 - ChatGPT is most useful when it turns ambiguous requests into product specs, acceptance criteria, and ADRs rather than trying to implement directly from a vague request.

--- a/manuscript-en/part-01-prompt/ch04-prompt-evals.md
+++ b/manuscript-en/part-01-prompt/ch04-prompt-evals.md
@@ -176,7 +176,7 @@ The important point is that prompt quality is not described as a feeling. It is 
 
 ## Source Notes / Further Reading
 - When you need to revisit this chapter, treat `evals/prompt-contract-cases.json`, `evals/rubrics/feature-spec.json`, and `scripts/run-prompt-evals.py` as the source of truth. Prompt quality should be judged by case and rubric deltas, not by tone or intuition.
-- For the next navigation step, see `manuscript/backmatter/00-source-notes.md` under `### CH04 プロンプトを評価する` and `manuscript/backmatter/01-読書案内.md` under `## Prompt と要求定義`.
+- For the next navigation step, see `manuscript-en/backmatter/00-source-notes.md` under `### CH04 Evaluate Prompts` and `manuscript-en/backmatter/01-reading-guide.md` under `## Prompts and Requirements Shaping`.
 
 ## Chapter Summary
 - Good prompts are judged by eval cases, rubrics, and regression checks rather than one-off success.

--- a/manuscript-en/part-02-context/ch05-context-fundamentals.md
+++ b/manuscript-en/part-02-context/ch05-context-fundamentals.md
@@ -125,7 +125,7 @@ Comparison points:
 
 ## Source Notes / Further Reading
 - When you need to revisit this chapter, treat `docs/context-model.md`, `docs/context-budget.md`, and `docs/context-risk-register.md` as the source of truth. Context Engineering is not a method for adding more text. It is a method for separating lifespan, authority, and refresh policy.
-- For the next navigation step, see `manuscript/backmatter/00-source-notes.md` under `### CH05 Context Engineering の基礎` and `manuscript/backmatter/01-読書案内.md` under `## Context と repo 設計`.
+- For the next navigation step, see `manuscript-en/backmatter/00-source-notes.md` under `### CH05 Foundations of Context Engineering` and `manuscript-en/backmatter/01-reading-guide.md` under `## Context and Repo Design`.
 
 ## Chapter Summary
 - Prompt Engineering defines the work boundary. Context Engineering defines the type, freshness, and priority of the decision material inside that boundary.

--- a/manuscript-en/part-02-context/ch06-repo-context.md
+++ b/manuscript-en/part-02-context/ch06-repo-context.md
@@ -139,7 +139,7 @@ Comparison points:
 
 ## Source Notes / Further Reading
 - When you need to revisit this chapter, start with `AGENTS.md`, `sample-repo/docs/repo-map.md`, `sample-repo/docs/architecture.md`, and `sample-repo/docs/coding-standards.md`. Read the repo map as the index and the architecture doc as the design rationale.
-- For the next navigation step, see `manuscript/backmatter/00-source-notes.md` under `### CH06 Repo Context を設計する` and `manuscript/backmatter/01-読書案内.md` under `## Context と repo 設計`.
+- For the next navigation step, see `manuscript-en/backmatter/00-source-notes.md` under `### CH06 Design Repo Context` and `manuscript-en/backmatter/01-reading-guide.md` under `## Context and Repo Design`.
 
 ## Chapter Summary
 - Repo Context does not exist to explain the whole repo. It exists to help the AI agent find the correct starting point and the correct update boundary quickly.

--- a/manuscript-en/part-02-context/ch07-task-context-and-memory.md
+++ b/manuscript-en/part-02-context/ch07-task-context-and-memory.md
@@ -149,7 +149,7 @@ Comparison points:
 
 ## Source Notes / Further Reading
 - To revisit this chapter quickly, start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, and `docs/session-memory-policy.md`. These three artifacts show the boundary between stable task context and mutable session context.
-- For the backmatter navigation path, see `manuscript/backmatter/00-source-notes.md` under `### CH07 Task Context と Session Memory` and `manuscript/backmatter/01-読書案内.md` under `## Context と repo 設計`.
+- For the backmatter navigation path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH07 Task Context and Session Memory` and `manuscript-en/backmatter/01-reading-guide.md` under `## Context and Repo Design`.
 
 ## Chapter Summary
 - A GitHub issue is too coarse to function as task context for a coding agent. It should be normalized into a task brief before execution starts.

--- a/manuscript-en/part-02-context/ch08-skills-and-context-pack.md
+++ b/manuscript-en/part-02-context/ch08-skills-and-context-pack.md
@@ -144,7 +144,7 @@ Comparison points:
 
 ## Source Notes / Further Reading
 - To revisit this chapter, start with `.agents/skills/draft-chapter/SKILL.md`, `.agents/skills/review-chapter/SKILL.md`, `sample-repo/.agents/skills/issue-to-plan/SKILL.md`, `sample-repo/.agents/skills/verification/SKILL.md`, and `sample-repo/context-packs/ticket-search.md`. Read the skills as reusable workflow contracts and the context pack as the task-specific minimum input.
-- For the backmatter path, see `manuscript/backmatter/00-source-notes.md` under `### CH08 Skills と Context Pack を再利用する` and `manuscript/backmatter/01-読書案内.md` under `## Context と repo 設計`.
+- For the backmatter path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH08 Reuse Skills and Context Packs` and `manuscript-en/backmatter/01-reading-guide.md` under `## Context and Repo Design`.
 
 ## Chapter Summary
 - A skill is not just a long prompt. It is an artifact that fixes a reusable workflow and output contract.

--- a/manuscript-en/part-03-harness/ch09-harness-fundamentals.md
+++ b/manuscript-en/part-03-harness/ch09-harness-fundamentals.md
@@ -197,7 +197,7 @@ The point of this example is not automation theater. The point is to show that H
 
 ## Source Notes / Further Reading
 - To revisit this chapter, start with `scripts/init.sh`, `sample-repo/docs/harness/single-agent-runbook.md`, `sample-repo/docs/harness/permission-policy.md`, and `sample-repo/docs/harness/done-criteria.md`. Read the single-agent harness as a bundle of startup, boundary, and exit conditions rather than as a prompt variant.
-- For the backmatter path, see `manuscript/backmatter/00-source-notes.md` under `### CH09 Harness Engineering の基礎` and `manuscript/backmatter/01-読書案内.md` under `## 検証・信頼性・運用`.
+- For the backmatter path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH09 Foundations of Harness Engineering` and `manuscript-en/backmatter/01-reading-guide.md` under `## Verification, Reliability, and Operations`.
 
 ## Chapter Summary
 - Context Engineering decides what the agent sees. Harness Engineering decides how the agent starts, where it must stop, and what must be true before it may declare completion.

--- a/manuscript-en/part-03-harness/ch10-verification-harness.md
+++ b/manuscript-en/part-03-harness/ch10-verification-harness.md
@@ -147,7 +147,7 @@ This table keeps the verification harness from collapsing into “the test chapt
 
 ## Source Notes / Further Reading
 - To revisit this chapter, start with `.github/workflows/verify.yml`, `checklists/verification.md`, `sample-repo/tests/test_ticket_search.py`, and `artifacts/evidence/README.md`. Read the verification harness as a flow across tests, CI, evidence, and approval rather than as a single command.
-- For the backmatter path, see `manuscript/backmatter/00-source-notes.md` under `### CH10 Verification Harness を作る` and `manuscript/backmatter/01-読書案内.md` under `## 検証・信頼性・運用`.
+- For the backmatter path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH10 Build a Verification Harness` and `manuscript-en/backmatter/01-reading-guide.md` under `## Verification, Reliability, and Operations`.
 
 ## Chapter Summary
 - A verification harness combines tests, execution order, evidence, CI, and approval gates into one verification system.

--- a/manuscript-en/part-03-harness/ch11-long-running-and-multi-agent.md
+++ b/manuscript-en/part-03-harness/ch11-long-running-and-multi-agent.md
@@ -174,7 +174,7 @@ This card keeps the decision grounded in integration cost instead of surface com
 
 ## Source Notes / Further Reading
 - To revisit this chapter, start with `sample-repo/docs/harness/feature-list.md`, `sample-repo/docs/harness/restart-protocol.md`, `sample-repo/docs/harness/multi-agent-playbook.md`, and `sample-repo/tasks/FEATURE-002-plan.md`. Read multi-agent work only after the role split and restart packet are concrete.
-- For the backmatter path, see `manuscript/backmatter/00-source-notes.md` under `### CH11 Long-running Task と Multi-agent` and `manuscript/backmatter/01-読書案内.md` under `## 検証・信頼性・運用`.
+- For the backmatter path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH11 Long-running Tasks and Multi-agent Work` and `manuscript-en/backmatter/01-reading-guide.md` under `## Verification, Reliability, and Operations`.
 
 ## Chapter Summary
 - Long-running tasks need a feature list, a Progress Note, and a restart packet to keep state stable across sessions.

--- a/manuscript-en/part-03-harness/ch12-operating-model.md
+++ b/manuscript-en/part-03-harness/ch12-operating-model.md
@@ -140,7 +140,7 @@ The point of this example is that adoption succeeds or fails based on whether ro
 
 ## Source Notes / Further Reading
 - To revisit this chapter, start with `docs/operating-model.md`, `docs/metrics.md`, `checklists/repo-hygiene.md`, and `.github/pull_request_template.md`. Read adoption decisions through roles, review budget, cadence, and cleanup instead of through model comparisons.
-- For the backmatter path, see `manuscript/backmatter/00-source-notes.md` under `### CH12 運用モデルと組織導入` and `manuscript/backmatter/01-読書案内.md` under `## 検証・信頼性・運用`.
+- For the backmatter path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH12 Operating Model and Organizational Adoption` and `manuscript-en/backmatter/01-reading-guide.md` under `## Verification, Reliability, and Operations`.
 
 ## Chapter Summary
 - Human responsibilities remain in goal setting, approval, final review, and repo hygiene.

--- a/scripts/verify-book.sh
+++ b/scripts/verify-book.sh
@@ -15,6 +15,10 @@ required=(
   "manuscript/backmatter/01-読書案内.md"
   "manuscript/backmatter/02-索引seed.md"
   "manuscript/backmatter/03-図表一覧方針.md"
+  "manuscript-en/backmatter/00-source-notes.md"
+  "manuscript-en/backmatter/01-reading-guide.md"
+  "manuscript-en/backmatter/02-index-seed.md"
+  "manuscript-en/backmatter/03-figure-table-list-policy.md"
   "manuscript/part-01-prompt/part-opener.md"
   "manuscript/part-02-context/part-opener.md"
   "manuscript/part-03-harness/part-opener.md"
@@ -72,7 +76,13 @@ required_part_openers = {
     "manuscript/part-02-context/part-opener.md": required_part_opener_sections,
     "manuscript/part-03-harness/part-opener.md": required_part_opener_sections,
 }
-required_sections_en = ["## Learning Objectives", "## Outline", "## Exercises", "## Referenced Artifacts"]
+required_sections_en = ["## Learning Objectives", "## Outline", "## Exercises", "## Referenced Artifacts", "## Source Notes / Further Reading"]
+required_backmatter_en = {
+    "manuscript-en/backmatter/00-source-notes.md": ["## What This Backmatter Does", "## Source Policy", "## Chapter-by-Chapter Source Notes"],
+    "manuscript-en/backmatter/01-reading-guide.md": ["## How to Use This Guide", "## Prompts and Requirements Shaping", "## Verification, Reliability, and Operations"],
+    "manuscript-en/backmatter/02-index-seed.md": ["## How to Use This Seed", "## Index Seed"],
+    "manuscript-en/backmatter/03-figure-table-list-policy.md": ["## Role", "## Figure List Policy", "## Table List Policy"],
+}
 
 
 def parse_artifacts(brief: Path) -> list[str]:
@@ -120,6 +130,14 @@ def chapter_title(ch_id: str) -> str:
             return line.removeprefix("# ").strip()
     raise SystemExit(f"chapter {ch_id} is missing a title heading")
 
+
+def english_chapter_title(ch_id: str) -> str:
+    chapter = expect_single_path(f"manuscript-en/**/{ch_id}-*.md", f"English chapter file for {ch_id}")
+    for line in chapter.read_text(encoding="utf-8").splitlines():
+        if line.startswith("# "):
+            return line.removeprefix("# ").strip()
+    raise SystemExit(f"English chapter {ch_id} is missing a title heading")
+
 def expect_single_path(pattern: str, label: str) -> Path:
     paths = sorted(root.glob(pattern))
     if not paths:
@@ -135,6 +153,8 @@ def check_english_chapter(ch_id: str, brief: Path):
     missing = [item for item in required_sections_en if item not in text]
     if missing:
         raise SystemExit(f"English chapter {ch_id} missing sections: {', '.join(missing)}")
+    if "manuscript/backmatter/" in text:
+        raise SystemExit(f"English chapter {ch_id} still points to Japanese backmatter")
     for artifact in parse_artifacts(brief):
         if not (root / artifact).exists():
             raise SystemExit(f"English brief {brief.name} references missing artifact: {artifact}")
@@ -145,6 +165,20 @@ def check_english_appendix(app_id: str, brief: Path):
     for artifact in parse_artifacts(brief):
         if not (root / artifact).exists():
             raise SystemExit(f"English brief {brief.name} references missing artifact: {artifact}")
+
+
+def check_english_backmatter(en_root: Path):
+    for rel, sections in required_backmatter_en.items():
+        text = (root / rel).read_text(encoding="utf-8")
+        missing = [item for item in sections if item not in text]
+        if missing:
+            raise SystemExit(f"English backmatter {rel} missing sections: {', '.join(missing)}")
+
+    source_notes = (en_root / "backmatter" / "00-source-notes.md").read_text(encoding="utf-8")
+    for brief in sorted((en_root / "briefs").glob("ch*.yaml")):
+        heading = f"### {brief.stem.upper()} {english_chapter_title(brief.stem)}"
+        if heading not in source_notes:
+            raise SystemExit(f"English source notes missing chapter heading: {heading}")
 
 
 def check_english_scaffold(target: str):
@@ -164,6 +198,8 @@ def check_english_scaffold(target: str):
         raise SystemExit("English chapter briefs do not match Japanese chapter briefs")
     if [p.stem for p in ja_app] != [p.stem for p in en_app]:
         raise SystemExit("English appendix briefs do not match Japanese appendix briefs")
+
+    check_english_backmatter(en_root)
 
     if target:
         brief = en_root / "briefs" / f"{target}.yaml"


### PR DESCRIPTION
## Summary
- add English backmatter artifacts for source notes, reading guide, index seed, and figure/table list policy
- align English CH01-CH12 chapter-end navigation to the English backmatter and add Source Notes / Further Reading to CH01
- extend verify-book so English chapters and backmatter are checked as part of the canonical scaffold

## Verification
- ./scripts/verify-book.sh

Closes #85
