### PR TITLE
Expand English README parity scope

### DIFF
--- a/manuscript-en/README.md
+++ b/manuscript-en/README.md
@@ -4,9 +4,9 @@ This directory holds the English manuscript counterpart for the book. The Englis
 
 ## Scope
 
-- Mirror the Japanese chapter and appendix layout
+- Mirror the Japanese front matter, chapter, appendix, backmatter, and figure layout
 - Keep one English brief for every Japanese brief
-- Keep one English counterpart for every Japanese chapter and appendix
+- Keep one English counterpart for every Japanese reader-facing artifact
 - Track parity status in `manuscript-en/STATUS.md`
 
 ## Directory Layout


### PR DESCRIPTION
## Summary
- expand `manuscript-en/README.md` scope so it explicitly covers front matter, backmatter, and figures in addition to chapters and appendices
- keep the Japanese manuscript as the canonical structural source while describing the actual English parity surface

## Verification
- ./scripts/verify-book.sh

Closes #103
