### PR TITLE
Normalize remaining verifier output wording

### DIFF
--- a/scripts/run-prompt-evals.py
+++ b/scripts/run-prompt-evals.py
@@ -114,7 +114,7 @@ def main() -> int:
     print(f"cases: {len(cases_doc['cases'])}")
     print(f"rubric: {rubric['name']}")
     print(f"criteria: {len(rubric['criteria'])}")
-    print("prompt eval scaffold looks consistent")
+    print("prompt eval artifacts look consistent")
     return 0
 
 

--- a/scripts/verify-sample.sh
+++ b/scripts/verify-sample.sh
@@ -28,4 +28,4 @@ for path in "${required[@]}"; do
 done
 
 PYTHONPATH="$SAMPLE/src" python3 -m unittest discover -s "$SAMPLE/tests" -v
-echo "sample scaffold looks consistent"
+echo "sample repository artifacts look consistent"


### PR DESCRIPTION
## Summary
- normalize the remaining verifier output messages that still said `scaffold looks consistent`
- align `verify-sample.sh` with the current repository-artifact terminology
- align `run-prompt-evals.py` with the current prompt-eval artifact terminology

## Verification
- ./scripts/verify-book.sh
- ./scripts/verify-sample.sh

Closes #108
