### PR TITLE
Refresh release plan with current phase status

### DIFF
--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -1,16 +1,32 @@
 # Release Plan
 
 ## M0 Scaffold
-骨格、sample-repo、AGENTS、skills、verify を整備する
+Status: completed
+
+骨格、sample-repo、AGENTS、skills、verify を整備する。
 
 ## M1 Prompt
-CH01-CH04 を執筆し、Prompt artifacts を固める
+Status: completed
+
+CH01-CH04 を執筆し、Prompt artifacts を固める。
 
 ## M2 Context
-CH05-CH08 を執筆し、brief / progress / skills / context pack を固める
+Status: completed
+
+CH05-CH08 を執筆し、brief / progress / skills / context pack を固める。
 
 ## M3 Harness
-CH09-CH12 を執筆し、verification / restart / operating model を固める
+Status: completed
+
+CH09-CH12 を執筆し、verification / restart / operating model を固める。
 
 ## M4 Polish
-appendix, glossary, cross-reference, technical pass
+Status: active
+
+appendix、glossary、cross-reference、technical pass、editorial cleanup を継続する。
+
+## Current Focus
+
+- review で見つかった drift を issue 単位で修正する
+- 日本語版と英語版の onboarding / parity docs を current state に保つ
+- verify 出力、cross-reference、support artifact の terminology drift を小さく解消する


### PR DESCRIPTION
## Summary
- update `docs/release-plan.md` so it shows the current phase status instead of reading like an untouched initial milestone sketch
- preserve the M0-M4 progression while marking completed phases and the current focus
- keep the document short and operational for contributors working issue by issue

## Verification
- ./scripts/verify-book.sh

Closes #110
