### PR TITLE
Refresh root onboarding inventory for current repo surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ prompts/en/    # 英語版 Prompt artifact
 checklists/    # review / verify / hygiene checklist
 checklists/en/ # 英語版 checklist
 evals/         # Prompt 評価用ファイル
-artifacts/     # evidence bundle などの共有 artifact
+artifacts/     # `artifacts/evidence/` を含む共有 artifact
 .agents/       # Codex 向け skills
 scripts/       # verify / GitHub bootstrap 用スクリプト
 templates/     # 日本語版で参照する再利用テンプレート

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,7 @@ book repo は日本語版 / 英語版の parity maintenance と polish を継続
 - GitHub repository、labels、milestones、issue / PR 運用は `main` 上で稼働している
 - 日本語版は front matter、CH01-CH12、appendices、backmatter、figures を含めて drafted 状態にある
 - 英語版は `manuscript-en/STATUS.md` の parity tracker に従って、front matter、CH01-CH12、appendices、backmatter、figures を drafted 状態で保持している
-- `sample-repo/`、`prompts/`、`checklists/`、`templates/`、`evals/`、`artifacts/` は本文参照と整合する状態に保たれている
+- `sample-repo/`、`prompts/`、`checklists/`、`templates/`、`evals/`、`artifacts/evidence/` は本文参照と整合する状態に保たれている
 - 英語版 support artifact として `docs/en/`、`prompts/en/`、`checklists/en/`、`templates/en/` を継続保守している
 - `scripts/bootstrap-github.sh`、`scripts/create-issues.py`、`issue-drafts/` は、この運用を別 repo に移植するための reusable setup artifact として残している
 


### PR DESCRIPTION
## Summary
- expand the root directory inventory so current support surfaces are visible to contributors
- update `STATUS.md` so English support artifacts and evidence storage are explicitly called out in current state
- keep the change limited to root onboarding docs

## Verification
- `./scripts/verify-book.sh`

## Remaining Gaps
- none

Closes #124
