### PR TITLE
Expose brief surfaces in manuscript inventories

### DIFF
--- a/manuscript-en/STATUS.md
+++ b/manuscript-en/STATUS.md
@@ -23,6 +23,7 @@
 
 | Surface | Japanese Source | English Target | Status |
 |---|---|---|---|
+| Briefs | `manuscript/briefs/` | `manuscript-en/briefs/` | drafted |
 | Front Matter | `manuscript/front-matter/` | `manuscript-en/front-matter/` | drafted |
 | Backmatter | `manuscript/backmatter/` | `manuscript-en/backmatter/` | drafted |
 | Figures | `manuscript/figures/` | `manuscript-en/figures/` | drafted |

--- a/manuscript/README.md
+++ b/manuscript/README.md
@@ -2,6 +2,7 @@
 
 ## 原稿構成
 
+- `briefs/`: 章 brief と appendix brief
 - `front-matter/`: はじめに、読み方ガイドなどの前付け
 - `part-00/`: 本文導入
 - `part-01-prompt/`, `part-02-context/`, `part-03-harness/`: 各 Part の opener と章本文


### PR DESCRIPTION
## Summary
- add `briefs/` to the Japanese manuscript layout inventory
- add a `Briefs` row to the English parity tracker
- keep the change limited to inventory and parity-surface visibility

## Verification
- `./scripts/verify-book.sh`

## Remaining Gaps
- none

Closes #126
