### PR TITLE
Align English appendix briefs with counterpart artifacts

### DIFF
--- a/manuscript-en/briefs/app-a.yaml
+++ b/manuscript-en/briefs/app-a.yaml
@@ -4,3 +4,5 @@ goal: Provide reusable templates or definitions used across the whole book.
 artifacts:
   - templates/prompt-contract.md
   - templates/prompt-rubric.md
+  - templates/en/prompt-contract.md
+  - templates/en/prompt-rubric.md

--- a/manuscript-en/briefs/app-b.yaml
+++ b/manuscript-en/briefs/app-b.yaml
@@ -5,3 +5,6 @@ artifacts:
   - templates/task-brief.md
   - templates/progress-note.md
   - templates/context-pack.md
+  - templates/en/task-brief.md
+  - templates/en/progress-note.md
+  - templates/en/context-pack.md

--- a/manuscript-en/briefs/app-c.yaml
+++ b/manuscript-en/briefs/app-c.yaml
@@ -5,3 +5,6 @@ artifacts:
   - templates/verify-checklist.md
   - templates/restart-protocol.md
   - templates/permission-policy.md
+  - templates/en/verify-checklist.md
+  - templates/en/restart-protocol.md
+  - templates/en/permission-policy.md

--- a/manuscript-en/briefs/app-d.yaml
+++ b/manuscript-en/briefs/app-d.yaml
@@ -3,3 +3,4 @@ title: Glossary
 goal: Provide reusable templates or definitions used across the whole book.
 artifacts:
   - docs/glossary.md
+  - docs/en/glossary.md

--- a/scripts/verify-book.sh
+++ b/scripts/verify-book.sh
@@ -177,6 +177,25 @@ forbidden_english_counterpart_phrases = {
         "Establish the directory contract for future English templates",
     ],
 }
+required_english_appendix_counterparts = {
+    "app-a": [
+        "templates/en/prompt-contract.md",
+        "templates/en/prompt-rubric.md",
+    ],
+    "app-b": [
+        "templates/en/task-brief.md",
+        "templates/en/progress-note.md",
+        "templates/en/context-pack.md",
+    ],
+    "app-c": [
+        "templates/en/verify-checklist.md",
+        "templates/en/restart-protocol.md",
+        "templates/en/permission-policy.md",
+    ],
+    "app-d": [
+        "docs/en/glossary.md",
+    ],
+}
 
 
 def parse_artifacts(brief: Path) -> list[str]:
@@ -256,9 +275,15 @@ def check_english_chapter(ch_id: str, brief: Path):
 
 def check_english_appendix(app_id: str, brief: Path):
     expect_single_path(f"manuscript-en/appendices/{app_id}-*.md", f"English appendix file for {app_id}")
-    for artifact in parse_artifacts(brief):
+    artifacts = parse_artifacts(brief)
+    for artifact in artifacts:
         if not (root / artifact).exists():
             raise SystemExit(f"English brief {brief.name} references missing artifact: {artifact}")
+    for artifact in required_english_appendix_counterparts.get(app_id, []):
+        if artifact not in artifacts:
+            raise SystemExit(
+                f"English appendix brief {brief.name} is missing counterpart artifact: {artifact}"
+            )
 
 
 def check_english_backmatter(en_root: Path):


### PR DESCRIPTION
Closes #130

## Goal
Align the English appendix brief layer with the English counterpart artifact surfaces that already exist under `templates/en/` and `docs/en/`.

## Changed Files
- `manuscript-en/briefs/app-a.yaml`
- `manuscript-en/briefs/app-b.yaml`
- `manuscript-en/briefs/app-c.yaml`
- `manuscript-en/briefs/app-d.yaml`
- `scripts/verify-book.sh`

## Verification
- `./scripts/verify-book.sh`

## Remaining Gaps
- none
