### PR TITLE
Track English support-artifact parity in manuscript-en docs

### DIFF
--- a/manuscript-en/AGENTS.md
+++ b/manuscript-en/AGENTS.md
@@ -9,6 +9,7 @@
 - 日本語版の chapter contract、artifact 参照、演習数を維持する
 - 日本語版にある具体例、bad / good example、artifact 参照を落とさない
 - 意訳で構成を崩さず、chapter / appendix / front matter / backmatter / figures の対応関係を守る
+- `docs/en/`、`prompts/en/`、`checklists/en/`、`templates/en/`、`artifacts/en/` の support artifact counterparts も追跡対象として扱う
 
 ## Chapter Contract
 英語版 chapter には次を含める。
@@ -31,5 +32,6 @@
 - chapter / appendix は日本語版 brief と対応させる
 - front matter / backmatter は対応する directory / file 構成と対応させる
 - figures は `manuscript/figures/figure-plan.md` と figure source 群と対応させる
+- support artifacts は `docs/`、`prompts/`、`checklists/`、`templates/`、`artifacts/` の対応する English counterpart と対応させる
 - 英語版の progress は `manuscript-en/STATUS.md` に反映する
 - 日本語版で artifact が増減したら、英語版 brief と status も追従させる

--- a/manuscript-en/README.md
+++ b/manuscript-en/README.md
@@ -7,6 +7,7 @@ This directory holds the English manuscript counterpart for the book. The Englis
 - Mirror the Japanese front matter, chapter, appendix, backmatter, and figure layout
 - Keep one English brief for every Japanese brief
 - Keep one English counterpart for every Japanese reader-facing artifact
+- Keep the English support-artifact surfaces under `docs/en/`, `prompts/en/`, `checklists/en/`, `templates/en/`, and `artifacts/en/` aligned with the Japanese source
 - Track parity status in `manuscript-en/STATUS.md`
 
 ## Directory Layout
@@ -29,12 +30,12 @@ manuscript-en/
 1. The Japanese manuscript remains the source for structure and artifact references.
 2. The English manuscript must preserve the same chapter ids, appendix ids, and referenced artifacts.
 3. Each English file should identify its Japanese source in `## Parity Notes` when the file contract requires it.
-4. When the Japanese manuscript changes structure or artifacts, the English counterpart and `manuscript-en/STATUS.md` must be updated in the same issue.
+4. When the Japanese manuscript or a reader-facing support artifact changes structure or artifacts, the English counterpart and `manuscript-en/STATUS.md` must be updated in the same issue.
 
 ## Editing Workflow
 
 1. Read the matching Japanese brief and chapter.
 2. Update the English brief first if scope changes.
-3. Update the English counterpart, draft, or reader-entry artifact.
+3. Update the English counterpart, draft, or reader-entry artifact, including support artifacts when the chapter depends on them.
 4. Update `manuscript-en/STATUS.md` if parity status changes.
 5. Run `./scripts/verify-book.sh`.

--- a/manuscript-en/STATUS.md
+++ b/manuscript-en/STATUS.md
@@ -27,6 +27,11 @@
 | Front Matter | `manuscript/front-matter/` | `manuscript-en/front-matter/` | drafted |
 | Backmatter | `manuscript/backmatter/` | `manuscript-en/backmatter/` | drafted |
 | Figures | `manuscript/figures/` | `manuscript-en/figures/` | drafted |
+| Docs Counterparts | `docs/` | `docs/en/` | drafted |
+| Prompt Counterparts | `prompts/` | `prompts/en/` | drafted |
+| Checklist Counterparts | `checklists/` | `checklists/en/` | drafted |
+| Template Counterparts | `templates/` | `templates/en/` | drafted |
+| Shared Artifact Counterparts | `artifacts/` | `artifacts/en/` | drafted |
 
 ## Status Meanings
 


### PR DESCRIPTION
Closes #136

## Goal
Reflect the current English support-artifact parity surfaces in the `manuscript-en` operating docs.

## Changed Files
- `manuscript-en/README.md`
- `manuscript-en/STATUS.md`
- `manuscript-en/AGENTS.md`

## Verification
- `./scripts/verify-book.sh`

## Remaining Gaps
- none
