### PR TITLE
Normalize task issue template wording and default label

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,8 +1,6 @@
 name: Task
-description: Chapter, scaffold, appendix, or polish task
+description: Chapter, repo, appendix, or polish task
 title: "[TASK] "
-labels:
-  - type/chapter
 body:
   - type: textarea
     id: goal


### PR DESCRIPTION
Closes #138

## Goal
Make the generic task issue template match the repository's current issue mix without mislabeling repo-level work as chapter work.

## Changed Files
- `.github/ISSUE_TEMPLATE/task.yml`

## Verification
- `./scripts/verify-book.sh`

## Remaining Gaps
- none
