### PR TITLE
[codex] add Japanese front matter safety notes

### DIFF
--- a/manuscript/front-matter/00-はじめに.md
+++ b/manuscript/front-matter/00-はじめに.md
@@ -34,6 +34,16 @@
 
 本書は、repo と artifact を持つ開発現場を前提にしている。そのため、コード変更や verify を伴わない利用形態には踏み込まない。
 
+## 前提知識
+
+本書を無理なく読むための前提は、次の 3 点である。
+
+- Git の基本操作と、差分・履歴・ブランチの役割を理解している
+- issue、spec、テスト、コードレビューを使った開発フローを知っている
+- repo を開き、ファイルを読んで変更し、verify を実行する流れに抵抗がない
+
+Python や特定フレームワークの深い知識は必須ではない。ただし、shell、CI、テスト実行、Pull Request といった artifact を実務で見たことがある方が、本書の価値は高くなる。
+
 ## この本で扱うことと扱わないこと
 
 扱うのは、AIエージェントに仕事を完了させるための設計である。具体的には、Prompt Contract、task brief、context pack、verification harness、restart packet、review budget といった artifact と運用である。
@@ -45,6 +55,25 @@
 - プロダクト組織全体の人事制度や評価制度
 
 本書では、必要な理論は扱う。ただし理論だけで終わらせず、必ず repo に残る artifact へ落とす。
+
+## 安全に使うための注意
+
+AIエージェントに repo 変更や verify を任せる運用は、そのまま本番へ持ち込んでよい前提ではない。特に次の点は先に確認する必要がある。
+
+- 権限境界: 書き込み権限、秘密情報、外部接続、課金対象 API の扱いを作業前に固定する
+- verify 境界: local test、CI、review 証跡のどこまでを通れば done と言えるかを先に決める
+- 監査性: Prompt、Context、Harness の変更を chat log ではなく repo artifact として残す
+
+本書の例は reader-facing な説明用に簡約している。実務へ移すときは、利用中のモデル、CLI、権限設定、組織ポリシー、法務要件を読者自身の環境に合わせて確認すること。
+
+## 利用と更新情報
+
+- 公開版: `https://itdojp.github.io/ai-agent-engineering-book/`
+- リポジトリ: `https://github.com/itdojp/ai-agent-engineering-book`
+- 更新差分: GitHub の commits / Pull Requests を参照する
+- Pages 生成の仕組み: `docs/pages-publishing.md`
+
+Prompt、Context、Harness に関わるツールや UI は更新頻度が高い。具体的な導入時は、本文だけでなく repository の最新差分と、利用中ツールの公式 documentation を併読することを前提にする。
 
 ## recurring case の見方
 

--- a/manuscript/front-matter/01-本書の読み方.md
+++ b/manuscript/front-matter/01-本書の読み方.md
@@ -46,6 +46,18 @@
 
 repo を先に眺めると、artifact の羅列に見えやすい。本文を先に読むと、なぜその artifact が必要かが分かりやすい。
 
+## 利用中ツールとの差分をどう扱うか
+
+本書で扱う prompt、context、harness の考え方は、特定の UI や単一のモデル名に依存しない。一方で、実際に使う ChatGPT、coding agent、CLI、CI は時点によって振る舞いが変わる。
+
+読み進めるときは、次の順で差分を確認すると安全である。
+
+1. 本書で固定したい artifact と判断基準を理解する
+2. repository の最新差分と `docs/pages-publishing.md`、`docs/operating-model.md` を確認する
+3. 実際に使うツールの公式 documentation で、権限、実行境界、verify 手順の最新仕様を確認する
+
+本文と利用中ツールの挙動が一致しない場合は、artifact と verify の考え方を優先し、個別手順は公式 source で読み替えることを勧める。
+
 ## recurring case の追い方
 
 本書の recurring case は、章ごとに次のように姿を変える。


### PR DESCRIPTION
## What changed
- added Japanese front matter guidance for prerequisites, safety boundaries, and update tracking
- added guidance on how to handle drift between the book and current tools

## Why
- the English front matter already carried these clarifications, but the Japanese front matter still lacked them

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
