### PR TITLE
[codex] rewrite-2026 wp-04 template guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,21 @@
 ## Goal
+- What outcome this PR is trying to achieve
 
 ## Scope and Non-goals
+- Included scope
+- Explicit non-goals / deferred work
 
 ## Changed Files
+- Key files or artifacts changed
 
 ## Verification
+- Current-run commands executed for this PR
 
 ## Evidence / Approval
+- Evidence bundle, approval boundary touched, or explicit approval still needed
 
 ## Remaining Gaps
+- Known follow-ups, risks, or deferred checks
 
 ## Notes for Review
+- Reviewer should confirm Goal / Changed Files / Scope and Non-goals / Verification / Evidence / Approval

--- a/checklists/repo-hygiene.md
+++ b/checklists/repo-hygiene.md
@@ -7,10 +7,11 @@
 - verify script と実態がずれていないか
 - `docs/glossary.md` を source of truth として表記を揃えたか
 - `Prompt Contract`、`Progress Note`、`verification harness` の固有表記がぶれていないか
+- approval boundary に触れる差分で、`Evidence / Approval` に承認主体と判断材料が残っているか
 - `needs-human-approval` の表記が `sample-repo/docs/harness/done-criteria.md` と矛盾していないか
 - 各章の `Source Notes / Further Reading` が `manuscript/backmatter/00-source-notes.md` と矛盾していないか
 - `manuscript/backmatter/00-source-notes.md` が CH01-CH12 を取りこぼしていないか
-- 出力契約の報告項目が `Changed Files`、`Verification`、`Remaining Gaps` に揃っているか
+- 出力契約の報告項目が `Goal`、`Scope and Non-goals`、`Changed Files`、`Verification`、`Evidence / Approval`、`Remaining Gaps` に揃っているか
 - local verify、CI、evidence の用語が chapter と checklist で矛盾していないか
 
 ## Weekly Cleanup


### PR DESCRIPTION
## Goal
- CH12 の operating model と review artifact の terminology を PR template / hygiene checklist に反映する。

## Scope and Non-goals
- Included scope:
  - `.github/pull_request_template.md`
  - `checklists/repo-hygiene.md`
- Non-goals:
  - CH12 本文の追加修正
  - sample-repo 側 artifact の再構成

## Changed Files
- `.github/pull_request_template.md`
  - 各 section に最小の記入ガイドを追加
  - reviewer が見るべき項目を `Goal / Changed Files / Scope and Non-goals / Verification / Evidence / Approval` に固定
- `checklists/repo-hygiene.md`
  - Before Merge に approval boundary と `Evidence / Approval` の確認を追加
  - PR 出力契約の項目を current template に合わせて更新

## Verification
- `git diff --check`
- `./scripts/verify-book.sh ch12`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`

## Evidence / Approval
- current-run verify はすべて通過
- approval boundary 自体は変更していない

## Remaining Gaps
- CH12 後続の backmatter / reading guide 整備は別 PR で扱う

## Notes for Review
- CH12 の用語と template / checklist の用語が揃っているかを確認してください。
