### PR TITLE
[codex] rewrite-2026 wp-05 backmatter operating terms

### DIFF
--- a/manuscript/backmatter/00-source-notes.md
+++ b/manuscript/backmatter/00-source-notes.md
@@ -73,10 +73,10 @@
 
 ### CH11 Long-running Task と Multi-agent
 
-- 最初に信頼するのは `sample-repo/docs/harness/feature-list.md`、`sample-repo/docs/harness/restart-protocol.md`、`sample-repo/docs/harness/multi-agent-playbook.md`、`sample-repo/tasks/FEATURE-002-plan.md` である。multi-agent は role split と restart packet が揃って初めて扱う。
+- 最初に信頼するのは `sample-repo/docs/harness/feature-list.md`、`sample-repo/docs/harness/restart-protocol.md`、`sample-repo/docs/harness/multi-agent-playbook.md`、`sample-repo/tasks/FEATURE-002-plan.md` である。multi-agent は role split と restart packet（canonical inputs）が揃って初めて扱う。
 - 外部 source を足すなら、使っている orchestration tool や task queue の公式 docs を優先する。並列化の議論を、write scope と handoff artifact から切り離さない。
 
 ### CH12 運用モデルと組織導入
 
-- 最初に信頼するのは `docs/operating-model.md`、`docs/metrics.md`、`checklists/repo-hygiene.md`、`.github/pull_request_template.md` である。運用モデルは役割、review budget、cadence、cleanup の組で読む。
+- 最初に信頼するのは `docs/operating-model.md`、`docs/metrics.md`、`checklists/repo-hygiene.md`、`.github/pull_request_template.md` である。運用モデルは Lead / Operator / Reviewer、approval boundary、review budget、cadence、cleanup の組で読む。
 - 外部 source を足すなら、組織が採用する review policy、release policy、metrics definition の公式文書を優先する。導入判断をモデル比較だけで閉じない。

--- a/manuscript/backmatter/01-読書案内.md
+++ b/manuscript/backmatter/01-読書案内.md
@@ -37,7 +37,7 @@
 | A2A の仕様、あるいは同等の agent handoff 仕様 | agent 間の task 移譲、handoff、状態共有の考え方 | CH07, CH11 |
 | GitHub / 利用中 VCS platform の official docs | issue、PR、review、branch protection、artifact 追跡 | CH03, CH06, CH10 |
 | 組織内の repo-map、architecture、coding standards | repo context の正本化、ownership の明確化 | CH06 |
-| handoff / incident / change log の組織ルール | session memory、resume packet、restart packet | CH07, CH11 |
+| handoff / incident / change log の組織ルール | session memory、restart packet、handoff contract | CH07, CH11 |
 
 ## 検証・信頼性・運用
 
@@ -48,10 +48,11 @@
 | Betsy Beyer ほか, *The Site Reliability Workbook* | checklist、runbook、運用設計の実装寄りの進め方 | CH09, CH10, CH11, CH12 |
 | Nicole Forsgren, Jez Humble, Gene Kim, *Accelerate* | metrics、throughput、運用改善の見方 | CH10, CH12 |
 | 組織内の approval / permission policy | human approval gate、越権防止、監査性 | CH09, CH12 |
+| 組織内の PR template / review checklist / merge policy | `Goal`、`Changed Files`、`Scope and Non-goals`、`Verification`、`Evidence / Approval`、review budget の運用 | CH10, CH12 |
 
 ## 使い分けの原則
 
 - Prompt の議論で迷ったら、まず official docs と local eval に戻る
 - Context の議論で迷ったら、repo artifact と ownership の正本に戻る
-- Harness の議論で迷ったら、verify、evidence、review policy の順に戻る
+- Harness と運用の議論で迷ったら、verify、evidence、approval boundary、review policy の順に戻る
 - 書籍や handbook は、local artifact の代わりではなく、判断軸を補うために使う


### PR DESCRIPTION
## Goal
Align WP-05 backmatter guidance with the operating-model terminology introduced in WP-04.

## Scope and Non-goals
- In scope: `manuscript/backmatter/00-source-notes.md`, `manuscript/backmatter/01-読書案内.md`
- Non-goals: glossary files, appendix A/B/C templates, source-note coverage beyond the wording sync

## Changed Files
- `manuscript/backmatter/00-source-notes.md`
- `manuscript/backmatter/01-読書案内.md`

## Verification
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`

## Evidence / Approval
- No approval-boundary changes; backmatter wording sync only

## Remaining Gaps
- Appendix A/B/C templates and remaining WP-05 source-note refinements will follow in a later slice

## Notes for Review
- Confirm that CH11/CH12 backmatter now uses the same terminology as WP-04 (`restart packet`, `approval boundary`, `Lead / Operator / Reviewer`, review budget).
