### PR TITLE
[codex] rewrite-2026 wp-05 prompt appendix terminology

### DIFF
--- a/manuscript/appendices/app-a-Prompt-テンプレート集.md
+++ b/manuscript/appendices/app-a-Prompt-テンプレート集.md
@@ -13,12 +13,16 @@ Template の各 section は次の役割を持つ。
 - `Objective`: 達成すべき結果を 1 文で固定する
 - `Inputs`: 参照すべき issue、spec、test、verify command を列挙する
 - `Constraints`: 既存契約、scope、更新必須 artifact を制限する
+- `Tool Contract`: 実行してよい command と外部接続の境界を固定する
+- `Approval Gate`: human approval が必要な操作を明示する
 - `Forbidden Actions`: 推測でやってはいけない変更を先に止める
 - `Missing Information Policy`: input 不足時に止まる条件と、仮定を置く条件を分ける
+- `Refusal / Stop Conditions`: 続行せず停止すべき条件を定義する
 - `Completion Criteria`: 完了判定を verify 可能な言葉で書く
+- `Output Schema`: output version と必須 section を固定する
 - `Output Format`: 最終報告の見出しを固定する
 
-たとえば bugfix なら `prompts/bugfix-contract.md`、feature なら `prompts/feature-contract.md` が実例になる。どちらも `Objective` と `Completion Criteria` は異なるが、構造は同じである。まず構造を固定し、その後に task 固有の差分だけを入れる。
+たとえば bugfix なら `prompts/bugfix-contract.md`、feature なら `prompts/feature-contract.md` が実例になる。どちらも `Objective` と `Completion Criteria` は異なるが、`Tool Contract`、`Approval Gate`、`Refusal / Stop Conditions`、`Output Schema` を含む構造は同じである。まず構造を固定し、その後に task 固有の差分だけを入れる。
 
 最小の埋め方は次のようになる。
 
@@ -36,13 +40,32 @@ Template の各 section は次の役割を持つ。
 - public interface を変更しない
 - failing test を先に追加または更新する
 
+## Tool Contract
+- 許可された verify / build / test コマンドだけを実行する
+- 明示されていない外部接続、依存追加、secret 利用は行わない
+
+## Approval Gate
+- 依存追加、破壊的変更、secret 利用、権限拡張は human approval を待つ
+
 ## Forbidden Actions
 - 無関係な refactor を混ぜない
 - verify を省略しない
 
+## Refusal / Stop Conditions
+- 必須 input が足りず、低リスクの仮定も置けない場合は停止する
+- source of truth が競合する場合は競合箇所を列挙して停止する
+
 ## Completion Criteria
 - 修正前は失敗し、修正後は成功する test がある
 - 指定 verify が通る
+
+## Output Schema
+- output_version: `2026-04-01`
+- required_sections:
+  - Root Cause
+  - Changed Files
+  - Verification
+  - Remaining Gaps
 ```
 
 Prompt Contract を書くときは、「実行前に agent を止める条件」と「実行後に完了を判断する条件」の両方を書く。片方しかない prompt は、指示としては読めても契約としては弱い。
@@ -51,7 +74,7 @@ Prompt Contract を書くときは、「実行前に agent を止める条件」
 
 `templates/prompt-rubric.md` は、prompt の良し悪しを比較するための rubric である。Prompt Engineering を偶然や好みに戻さないために使う。CH04 で扱ったように、prompt を改善したかどうかは、eval case と rubric で判断する。
 
-rubric では、次の観点を最低限そろえるとよい。
+rubric では、`checklists/prompt-contract-review.md` と同じ観点を最低限そろえるとよい。
 
 - `Goal clarity`: 何を達成する prompt かが明確か
 - `Input completeness`: 必要 artifact や source of truth が不足していないか
@@ -59,6 +82,8 @@ rubric では、次の観点を最低限そろえるとよい。
 - `Forbidden action clarity`: 壊れやすい逸脱を明示的に禁止しているか
 - `Verifiability`: 完了条件が verify 可能か
 - `Output format specificity`: 最終出力が review しやすい形に固定されているか
+- `Approval gate clarity`: human approval が必要な操作が明示されているか
+- `Stop condition clarity`: 止まるべき条件が先に定義されているか
 
 実務では 0 から 2 の三段階で十分なことが多い。重要なのは細かい採点ではなく、「前の prompt より何が改善したか」を case ごとに説明できることだ。rubric がないと、出力がたまたま良かった prompt を保存してしまい、次回の regression に気づけない。
 


### PR DESCRIPTION
## Goal
Align appendix A with the 2026 Prompt Contract terminology and review checklist.

## Scope and Non-goals
- In scope: `manuscript/appendices/app-a-Prompt-テンプレート集.md`
- Non-goals: appendix B/C, glossary files, prompt artifacts themselves

## Changed Files
- `manuscript/appendices/app-a-Prompt-テンプレート集.md`

## Verification
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`

## Evidence / Approval
- No approval-boundary changes; appendix wording sync only

## Remaining Gaps
- Appendix B still needs WP-05 terminology alignment

## Notes for Review
- Confirm appendix A now reflects `Tool Contract`, `Approval Gate`, `Refusal / Stop Conditions`, `Output Schema`, and the current prompt review checklist terminology.
