### PR TITLE
[codex] rewrite-2026 wp-06 normalize sample support wording

### DIFF
--- a/sample-repo/.agents/skills/verification/SKILL.md
+++ b/sample-repo/.agents/skills/verification/SKILL.md
@@ -11,10 +11,10 @@ support-hub の変更に対する検証を標準化する。
 1. impacted tests を確認する
 2. `python -m unittest discover -s tests -v` を実行する
 3. docs drift がないか確認する
-4. progress note を更新する
+4. `Progress Note` を更新する
 
 ## Output Contract
 - 実行した verify command
 - pass / fail
 - docs drift の有無
-- progress note へ残す要点
+- `Progress Note` へ残す要点

--- a/sample-repo/context-packs/ticket-search.md
+++ b/sample-repo/context-packs/ticket-search.md
@@ -23,7 +23,7 @@
 ## Live Checks
 - 最新の `python -m unittest discover -s tests -v` 結果
 - `tests/test_ticket_search.py` の期待値
-- 直近の progress note
+- 直近の `Progress Note`
 
 ## Exclusions
 - relevance ranking
@@ -34,4 +34,4 @@
 ## Done Signals
 - docs、tests、実装が同じ挙動を説明している
 - verify が通る
-- progress note が更新されている
+- `Progress Note` が更新されている

--- a/sample-repo/docs/coding-standards.md
+++ b/sample-repo/docs/coding-standards.md
@@ -11,7 +11,7 @@
 
 - docstring より task brief / architecture docs を優先する
 - 仕様変更時は product spec、acceptance criteria、ADR を同時更新する
-- 中断や handoff が発生する変更では progress note を更新する
+- 中断や handoff が発生する変更では `Progress Note` を更新する
 - TODO を残す場合は task brief または issue と結びつける
 
 ## Scope Guard

--- a/sample-repo/docs/harness/permission-policy.md
+++ b/sample-repo/docs/harness/permission-policy.md
@@ -8,7 +8,7 @@ single-agent harness で、coding agent が自律で進めてよい変更と hum
 - failing test の追加または更新
 - 変更した挙動に追随する docs / task artifact の同期
 - read-only の調査コマンド、`./scripts/verify-sample.sh` の実行
-- scope 内の progress note 更新
+- scope 内の `Progress Note` 更新
 - current session で完結する foreground command の実行
 
 ## Require Human Approval

--- a/sample-repo/docs/repo-map.md
+++ b/sample-repo/docs/repo-map.md
@@ -37,4 +37,4 @@
 
 ## Update Guide
 - 振る舞い変更時は code だけでなく docs / tests / task artifacts を同時に更新する
-- 変更対象が `service.py` なら、関連する acceptance criteria と progress note を確認する
+- 変更対象が `service.py` なら、関連する acceptance criteria と `Progress Note` を確認する

--- a/sample-repo/tasks/BUG-001-brief.md
+++ b/sample-repo/tasks/BUG-001-brief.md
@@ -7,7 +7,7 @@
 - failing test design
 - root cause hypothesis
 - fix plan
-- progress note
+- `Progress Note`
 
 ## Out of Scope
 - UI 層の実装

--- a/sample-repo/tasks/FEATURE-001-brief.md
+++ b/sample-repo/tasks/FEATURE-001-brief.md
@@ -10,7 +10,7 @@
 ## Scope
 - `search_tickets` の検索挙動を `title`、`description`、`tags` の部分一致に揃える
 - product spec、acceptance criteria、ADR を現行挙動と同期する
-- progress note に判断と verify 結果を残す
+- `Progress Note` に判断と verify 結果を残す
 
 ## Inputs
 - `docs/product-specs/ticket-search.md`
@@ -22,7 +22,7 @@
 ## Deliverables
 - 検索関連 docs の更新
 - 必要なら code / tests の更新
-- progress note の更新
+- `Progress Note` の更新
 
 ## Constraints
 - `list_tickets` の既存 public contract は変更しない


### PR DESCRIPTION
## What changed
- normalized selected sample-repo support artifacts to use the canonical `Progress Note` term
- aligned support docs, briefs, context packs, and the embedded verification skill wording within this slice

## Why
- WP-06 is standardizing sample-repo support artifacts around one canonical term
- this slice addresses the wording drift in the support docs grouped in this PR, without broadening scope to unrelated artifacts

## Impact
- readers and contributors see one canonical term across the support docs touched in this PR
- no behavioral change; wording-only consistency update

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`
