### PR TITLE
[codex] rewrite-2026 wp-06 canonicalize progress note artifact names

### DIFF
--- a/sample-repo/AGENTS.md
+++ b/sample-repo/AGENTS.md
@@ -7,7 +7,7 @@ support-hub サンプル実装向けの instructions。
 - まず `docs/repo-map.md` と `docs/architecture.md` を読む
 - public API を壊す場合は brief と docs を更新する
 - test を追加または更新してから本体を変える
-- `tasks/` の task brief / progress note を更新する
+- `tasks/` の task brief / `Progress Note` を更新する
 - 変更が docs に影響するなら同時に更新する
 
 ## Verification

--- a/sample-repo/tasks/FEATURE-001-progress.md
+++ b/sample-repo/tasks/FEATURE-001-progress.md
@@ -1,4 +1,4 @@
-# FEATURE-001 Progress
+# FEATURE-001 Progress Note
 
 ## Status
 ready-for-handoff


### PR DESCRIPTION
## What changed
- canonicalized the entry-point artifact labels in `sample-repo/AGENTS.md` and `sample-repo/tasks/FEATURE-001-progress.md` to `Progress Note`
- aligned the agent instruction entry point and the sample progress artifact title within this focused slice

## Why
- WP-06 is standardizing sample-repo support artifacts around one canonical term
- these two entry-point files still exposed the legacy label and were a coherent wording-only slice to fix independently

## Impact
- contributors now see the canonical artifact name at the main instruction entry point and in the sample progress artifact itself
- wording-only change; no behavioral or workflow change

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`
