### PR TITLE
[codex] rewrite-2026 wp-06 canonicalize Progress Note in english context artifacts

### DIFF
--- a/manuscript-en/appendices/app-b-context-templates.md
+++ b/manuscript-en/appendices/app-b-context-templates.md
@@ -61,7 +61,7 @@ The basic structure is:
 - `Purpose`: which task this context pack supports
 - `Read Order`: the sequence in which artifacts should be read
 - `Canonical Facts`: the facts this task must not override
-- `Live Checks`: the latest verification, progress note, or state checks that must be refreshed each time
+- `Live Checks`: the latest verification, `Progress Note`, or state checks that must be refreshed each time
 - `Exclusions`: the topics intentionally left out of this task
 - `Done Signals`: the conditions that tell the worker the task is actually complete
 

--- a/manuscript-en/briefs/ch07.yaml
+++ b/manuscript-en/briefs/ch07.yaml
@@ -1,23 +1,23 @@
 id: ch07
 title: Task Context and Session Memory
 part: part-02-context
-goal: Convert issues into task briefs, and design progress notes and handoffs so coding agent work survives across sessions.
+goal: Convert issues into task briefs, and design the Progress Note artifact and handoffs so coding agent work survives across sessions.
 reader_outcomes:
   - Convert a GitHub issue into a task brief
-  - Understand the minimum fields in a coding agent progress note
+  - Understand the minimum fields in a coding agent Progress Note
   - Design a workflow that prevents summary drift
 dependencies:
   - ch05
   - ch06
 sections:
   - Convert an issue into a task brief
-  - Format a coding agent progress note
+  - Format a coding agent Progress Note
   - Design handoff and resume
   - Avoid summary drift
   - Minimum inputs for session restart
 exercises:
   - Convert a GitHub issue into a task brief.
-  - Build a resume packet that starts from a progress note and includes the task brief and verify result.
+  - Build a resume packet that starts from a Progress Note and includes the task brief and verify result.
 artifacts:
   - sample-repo/tasks/FEATURE-001-brief.md
   - sample-repo/tasks/FEATURE-001-progress.md

--- a/manuscript-en/part-02-context/ch05-context-fundamentals.md
+++ b/manuscript-en/part-02-context/ch05-context-fundamentals.md
@@ -45,12 +45,12 @@ The opposite mistake also fails. A large pile of docs and tests cannot compensat
 
 - Persistent context: relatively stable repo rules such as `AGENTS.md`, architecture docs, glossary entries, and coding standards
 - Task context: issue-specific scope and done conditions such as the issue, task brief, product spec, ADR, and acceptance criteria
-- Session context: restart-oriented records such as progress notes, open questions, the latest decision summary, and the next step
+- Session context: restart-oriented records such as the `Progress Note`, open questions, the latest decision summary, and the next step
 - Tool context: live evidence such as grep output, test results, verify logs, and screenshots
 
 For `FEATURE-001`, `sample-repo/docs/architecture.md` is persistent context. `sample-repo/tasks/FEATURE-001-brief.md` is task context. `sample-repo/tasks/FEATURE-001-progress.md` is session context. The latest `python -m unittest discover -s tests -v` output is tool context. If these all get dumped into one memo, old decisions and live failures start to look equally authoritative.
 
-The separation matters because the update speed is different. Architecture docs do not change every session. Progress notes do. Verify output can become obsolete within minutes. Context Engineering treats those differences as design constraints rather than accidents.
+The separation matters because the update speed is different. Architecture docs do not change every session. The `Progress Note` does. Verify output can become obsolete within minutes. Context Engineering treats those differences as design constraints rather than accidents.
 
 ## 3. Think in Context Budgets
 A context budget is not only about token limits. It is a design policy for what should stay verbatim, what should be summarized, and what should be dropped. `docs/en/context-budget.md` gives that policy explicitly: keep acceptance criteria, interface contracts, verify commands, and destructive-change constraints verbatim; summarize exploratory logs and comparison history; drop stale test output and expired hypotheses.
@@ -66,10 +66,10 @@ The operational rule is straightforward:
 
 - repo principles such as `sample-repo/docs/architecture.md` and `sample-repo/docs/coding-standards.md` are stale-safe starting points
 - task artifacts such as a task brief or acceptance criteria must be reread for the current issue
-- progress notes are useful session memory, but they become stale as soon as verify results change
+- the `Progress Note` is useful session memory, but it becomes stale as soon as verify results change
 - terminal output and failing test logs are live context and should be refreshed rather than trusted from memory
 
-In `FEATURE-001`, `sample-repo/docs/repo-map.md` and `sample-repo/docs/architecture.md` are safe entry points. `sample-repo/tasks/FEATURE-001-progress.md` is less stable. If the progress note says the last verify passed, that statement may already be obsolete by the next session. Restarting from the note alone is not enough. The safe action is to reread the note, then rerun verify if the current task depends on it.
+In `FEATURE-001`, `sample-repo/docs/repo-map.md` and `sample-repo/docs/architecture.md` are safe entry points. `sample-repo/tasks/FEATURE-001-progress.md` is less stable. If the `Progress Note` says the last verify passed, that statement may already be obsolete by the next session. Restarting from the note alone is not enough. The safe action is to reread the note, then rerun verify if the current task depends on it.
 
 ## 5. Prevent Context Poisoning and Drift
 Context Engineering fails not only when information is missing, but also when the wrong information keeps circulating. `docs/en/context-risk-register.md` lists the main risks: stale docs, summary drift, instruction bloat, context poisoning, hidden done criteria, and tool spam.
@@ -77,10 +77,10 @@ Context Engineering fails not only when information is missing, but also when th
 Three failure patterns appear often:
 
 1. docs and tests drift apart, so implementation follows an obsolete spec
-2. a progress note writes an unverified guess under `Decided`, and the next session treats it as fact
+2. a `Progress Note` writes an unverified guess under `Decided`, and the next session treats it as fact
 3. `AGENTS.md` or handoff notes grow until the important constraints are buried
 
-The countermeasures are structural. Keep canonical artifacts in the task brief and acceptance criteria. Separate `Decided` from `Open Questions` in the progress note. Move long logs out of the standing context and keep them as evidence instead. When live evidence can be rerun, rerun it before trusting an old summary.
+The countermeasures are structural. Keep canonical artifacts in the task brief and acceptance criteria. Separate `Decided` from `Open Questions` in the `Progress Note`. Move long logs out of the standing context and keep them as evidence instead. When live evidence can be rerun, rerun it before trusting an old summary.
 
 Context Engineering is not only a technique for adding information. It is also a technique for preventing broken information from surviving too long.
 
@@ -104,7 +104,7 @@ Then provide context in this order:
 3. `sample-repo/docs/acceptance-criteria/ticket-search.md`
 4. `sample-repo/tasks/FEATURE-001-progress.md`
 5. the latest verify result
-Do not keep full historical logs in the standing context. Promote only the conclusions that must survive into the progress note.
+Do not keep full historical logs in the standing context. Promote only the conclusions that must survive into the `Progress Note`.
 ```
 
 This version separates the contract from the decision material and also separates stale-safe docs from live verify evidence.

--- a/manuscript-en/part-02-context/ch07-task-context-and-memory.md
+++ b/manuscript-en/part-02-context/ch07-task-context-and-memory.md
@@ -22,12 +22,12 @@ This chapter shows how to turn an issue into a task brief, how to structure a Pr
 
 ## Learning Objectives
 - Convert a GitHub issue into a task brief
-- Understand the minimum fields in a coding agent progress note
+- Understand the minimum fields in a coding agent `Progress Note`
 - Design a workflow that prevents summary drift
 
 ## Outline
 ### 1. Convert an issue into a task brief
-### 2. Format a coding agent progress note
+### 2. Format a coding agent `Progress Note`
 ### 3. Design handoff and resume
 ### 4. Avoid summary drift
 ### 5. Define minimum inputs for session restart
@@ -139,7 +139,7 @@ Comparison points:
 
 ## Exercises
 1. Convert a GitHub issue into a task brief.
-2. Build a resume packet that starts from a progress note and includes the task brief and verify result.
+2. Build a resume packet that starts from a `Progress Note` and includes the task brief and verify result.
 
 ## Referenced Artifacts
 - `sample-repo/tasks/FEATURE-001-brief.md`

--- a/templates/en/context-pack.md
+++ b/templates/en/context-pack.md
@@ -10,7 +10,7 @@
 - Record the facts this task must not override.
 
 ## Live Checks
-- Record the verification state, progress note, and other current checks that must be refreshed each time.
+- Record the verification state, `Progress Note`, and other current checks that must be refreshed each time.
 
 ## Exclusions
 - State the topics intentionally left out of this task.


### PR DESCRIPTION
## What changed
- canonicalized remaining lowercase `progress note` wording in English context-side artifacts
- updated CH05 and CH07 English manuscript text, the CH07 brief, appendix B, and the English context pack template
- kept the slice wording-only and aligned it with the already merged Japanese WP-06 terminology cleanup

## Why
The Japanese side is now aligned on the canonical artifact name `Progress Note`, but the English context-side materials still used mixed lowercase wording. That left the glossary and chapter terminology out of sync across languages.

## Impact
- English context chapters and support artifacts use the same canonical artifact name
- CH07 brief metadata and appendix/template wording now match the glossary and session-memory policy
- no behavioral or sample code changes

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`
