### PR TITLE
[codex] rewrite-2026 wp-06 canonicalize Progress Note in english harness artifacts

### DIFF
--- a/manuscript-en/briefs/ch11.yaml
+++ b/manuscript-en/briefs/ch11.yaml
@@ -1,7 +1,7 @@
 id: ch11
 title: Long-running Tasks and Multi-agent Work
 part: part-03-harness
-goal: Define the feature list, restart protocol, and progress notes needed for long-running tasks, and split into multi-agent only when needed.
+goal: Define the feature list, restart protocol, and the Progress Note artifact needed for long-running tasks, and split into multi-agent only when needed.
 reader_outcomes:
   - Explain why long-running tasks break
   - Design a restart protocol

--- a/manuscript-en/part-00/ch01-failure-model.md
+++ b/manuscript-en/part-00/ch01-failure-model.md
@@ -60,7 +60,7 @@ In `sample-repo/docs/seed-issues.md`, the recurring cases line up with these fai
 | Failure Mode | Typical `sample-repo` Example | First Missing Artifact to Suspect |
 |---|---|---|
 | Wrong answer | Guessing the search scope in `FEATURE-001` | The issue boundary and domain understanding |
-| Forgetting | Losing decisions during `FEATURE-002` | The task brief and progress note |
+| Forgetting | Losing decisions during `FEATURE-002` | The task brief and `Progress Note` |
 | Breaking things | Fixing `BUG-001` while drifting from docs or adjacent behavior | Tests and impact analysis |
 | Stopping early | Treating `HARNESS-001` as done before verification and evidence | The verification harness and done criteria |
 


### PR DESCRIPTION
## What changed
- canonicalized the remaining lowercase `progress note` wording in the English harness-side artifacts
- updated the failure-model table in CH01 and the CH11 brief metadata to use the canonical `Progress Note` artifact name
- kept the slice wording-only and aligned it with the merged WP-06 terminology cleanup on the Japanese side

## Why
After the English context-side parity slice, the remaining lowercase wording was limited to the failure-model overview and the CH11 brief metadata. Leaving those behind would keep the English harness terminology slightly inconsistent with the glossary and restart artifacts.

## Impact
- the failure-model overview and CH11 brief now use the same canonical artifact name as the rest of the rewrite
- no behavioral, sample code, or verification flow changes

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`
