### PR TITLE
[codex] rewrite-2026 wp-05 expand index seed for operating terms

### DIFF
--- a/manuscript/backmatter/02-索引seed.md
+++ b/manuscript/backmatter/02-索引seed.md
@@ -13,6 +13,8 @@
 | 見出し語 | 主に戻る章 | primary artifact / 補助参照 |
 |---|---|---|
 | acceptance criteria | CH03, CH10 | `sample-repo/docs/acceptance-criteria/ticket-search.md`, `sample-repo/tests/test_ticket_search.py` |
+| A2A | Appendix D | `docs/glossary.md` |
+| approval boundary | CH09, CH12 | `sample-repo/docs/harness/permission-policy.md`, `docs/operating-model.md` |
 | ADR | CH03 | `sample-repo/docs/design-docs/ticket-search-adr.md` |
 | AGENTS.md | CH06 | `AGENTS.md`, `manuscript/AGENTS.md`, `sample-repo/AGENTS.md` |
 | AI agent | CH01, CH12 | `docs/glossary.md`, `docs/operating-model.md` |
@@ -25,9 +27,13 @@
 | Context Engineering | CH01, CH05 | `docs/context-model.md` |
 | done criteria | CH09 | `sample-repo/docs/harness/done-criteria.md` |
 | evidence bundle | CH10 | `artifacts/evidence/README.md` |
+| hygiene backlog age | CH12 | `docs/metrics.md` |
+| Lead / Operator / Reviewer | CH12 | `docs/operating-model.md`, `.github/pull_request_template.md` |
+| MCP | Appendix D | `docs/glossary.md` |
 | feature list | CH11 | `sample-repo/docs/harness/feature-list.md` |
 | Harness Engineering | CH01, CH09 | `sample-repo/docs/harness/single-agent-runbook.md` |
 | operating model | CH12 | `docs/operating-model.md` |
+| approval-stop rate | CH12 | `docs/metrics.md` |
 | permission policy | CH09 | `sample-repo/docs/harness/permission-policy.md` |
 | Progress Note | CH07 | `sample-repo/tasks/FEATURE-001-progress.md` |
 | Prompt Contract | CH02 | `prompts/bugfix-contract.md`, `prompts/feature-contract.md` |
@@ -37,10 +43,13 @@
 | restart packet | CH11 | `sample-repo/docs/harness/restart-protocol.md` |
 | review budget | CH12 | `docs/operating-model.md`, `docs/metrics.md` |
 | rubrics | CH04 | `evals/rubrics/feature-spec.json` |
+| provenance | Appendix D | `docs/glossary.md`, `artifacts/evidence/README.md` |
 | sample-repo | CH01 | `sample-repo/README.md`, `sample-repo/docs/domain-overview.md` |
 | session memory | CH07 | `docs/session-memory-policy.md` |
 | skill | CH08 | `.agents/skills/draft-chapter/SKILL.md`, `sample-repo/.agents/skills/verification/SKILL.md` |
 | source notes | この後付け | `manuscript/backmatter/00-source-notes.md` |
+| source hierarchy | Appendix D | `docs/glossary.md`, `manuscript/backmatter/00-source-notes.md` |
+| stale draft count | CH12 | `docs/metrics.md` |
 | task brief | CH07 | `sample-repo/tasks/FEATURE-001-brief.md` |
 | verification harness | CH10 | `.github/workflows/verify.yml`, `checklists/verification.md` |
 | work package | CH11, CH12 | `sample-repo/tasks/FEATURE-002-plan.md`, `docs/operating-model.md` |


### PR DESCRIPTION
## What changed
- expanded `manuscript/backmatter/02-索引seed.md` to cover the 2026 rewrite terms added across WP-04 and WP-05
- added entries for protocol, approval, operating-model, and metrics vocabulary that was missing from the index seed
- kept the slice limited to backmatter indexing and cross-reference guidance

## Why
The glossary and operating-model docs already define terms such as `approval boundary`, `Lead / Operator / Reviewer`, `MCP`, `A2A`, and metrics like `stale draft count`, but the index seed did not yet route readers back to those sections. This left the backmatter incomplete relative to the revised text.

## Impact
- the backmatter index seed better reflects the current 2026 terminology set
- readers can navigate from new governance / protocol terms back to the relevant chapters and artifacts
- no behavioral or sample code changes

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`
