### PR TITLE
[codex] rewrite-2026 wp-03 close out context restart artifacts

### DIFF
--- a/docs/en/session-memory-policy.md
+++ b/docs/en/session-memory-policy.md
@@ -15,9 +15,10 @@ Make it possible to return to the same task brief and the same verification evid
 - `Resume Steps`: the files to reopen and the reading order
 - `Next Step`: the single next action
 
-## Optional Field
+## Optional Fields
 
 - `Status`: a short state label for quick scanning; do not treat it as the source of truth
+- `Blocking / Approval`: record the blocking reason, required human decision, and restart condition only when the task stops at an approval boundary
 
 ## What Not to Store
 
@@ -26,12 +27,14 @@ Make it possible to return to the same task brief and the same verification evid
 - unverified assertions
 - duplicated information that already exists in the task brief
 
-## Minimum Input for a Resume Packet
+## Minimum Input for a Restart Packet (Resume Packet)
 
 1. the task brief
 2. the latest Progress Note
 3. the latest verify result
 4. the list of files that should be read first when resuming
+
+When the task stops at an approval boundary, also record the pending decision, attached evidence, and the human input required to restart in `Blocking / Approval`.
 
 ## Drift Guard
 
@@ -39,6 +42,8 @@ Make it possible to return to the same task brief and the same verification evid
 - do not put unresolved items into `Decided`
 - do not split the summary into separate before-verify and after-verify narratives
 - when an open question is resolved, promote it to `Decided` instead of silently deleting it
+- do not let the Progress Note restate Goal or Constraints in a way that overwrites the stable task context
+- if work stops at an approval boundary, state what kind of change would cross that boundary
 
 ## Update Timing
 
@@ -46,3 +51,4 @@ Make it possible to return to the same task brief and the same verification evid
 - right after verify finishes
 - before handoff
 - when an important design decision becomes fixed
+- when work is paused pending approval

--- a/docs/session-memory-policy.md
+++ b/docs/session-memory-policy.md
@@ -26,7 +26,7 @@
 - 未検証の断定
 - 既に task brief にある情報の重複
 
-## Resume Packet の最低入力
+## Restart Packet（Resume Packet）の最低入力
 
 1. task brief
 2. 最新 `Progress Note`
@@ -34,6 +34,8 @@
 4. 再開時に読むべきファイル一覧
 
 approval boundary で止まったときは、上記に加えて pending な判断、添付済み evidence、再開に必要な human decision を `Blocking / Approval` に残す。
+
+`docs/en/session-memory-policy.md` は本書と整合させる。`Blocking / Approval` を追加・変更した場合は、同等の項目名と説明、関連する `Restart Packet` / Drift Guard / 更新タイミングも英語版へ反映する。
 
 ## Drift Guard
 

--- a/manuscript/part-02-context/part-opener.md
+++ b/manuscript/part-02-context/part-opener.md
@@ -10,7 +10,7 @@ Context Engineering では次の順に積み上げる。
 
 1. context の種類と budget を分ける
 2. repo context で永続コンテキストの入口を作る
-3. task brief と Session Memory で今回の作業と現在位置を固定する
+3. task brief、Session Memory、restart packet で今回の作業と現在位置を固定する
 4. skill と context pack で再利用可能な作業単位にする
 
 ## この Part で増える artifact

--- a/sample-repo/context-packs/ticket-search.md
+++ b/sample-repo/context-packs/ticket-search.md
@@ -25,14 +25,14 @@
 1. `tasks/FEATURE-001-brief.md`
 2. `docs/acceptance-criteria/ticket-search.md`
 3. `docs/product-specs/ticket-search.md` と `docs/design-docs/ticket-search-adr.md`
-4. 最新の `Progress Note` と verify 出力
+4. この task の `Progress Note`（`tasks/FEATURE-001-progress.md`）と verify 出力
 
 `Progress Note` と verify は session memory / live evidence であり、brief や acceptance criteria を上書きしない。
 
 ## Live Checks
 - 最新の `python -m unittest discover -s tests -v` 結果
 - `tests/test_ticket_search.py` の期待値
-- 直近の `Progress Note`
+- 直近の `tasks/FEATURE-001-progress.md`
 - public contract や scope を越える変更が approval boundary に当たらないか
 
 ## Approval Boundary

--- a/sample-repo/docs/repo-map.md
+++ b/sample-repo/docs/repo-map.md
@@ -32,7 +32,7 @@
 
 ## Task Artifacts
 - `tasks/`: brief / Progress Note / plan
-- `context-packs/`: task specific context pack、canonical facts、live checks
+- `context-packs/`: task specific context pack / canonical facts / live checks
 - `.agents/skills/`: repeatable workflow
 
 ## Update Guide


### PR DESCRIPTION
## Summary
- refresh the Part II opener to frame restart packet and approval-pending context
- tighten session memory and repo-map guidance around approval boundaries and restart inputs
- add source hierarchy and approval-boundary guidance to the ticket-search context pack

## Testing
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh

Closes #156