### PR TITLE
[codex] align EN CH07 restart packet terminology

### DIFF
--- a/manuscript-en/part-02-context/ch07-task-context-and-memory.md
+++ b/manuscript-en/part-02-context/ch07-task-context-and-memory.md
@@ -55,8 +55,8 @@ The purpose of this format is not to preserve every step of exploration. Its pur
 
 The most common mistake is to paste brief content into the Progress Note. Goal, constraints, and acceptance criteria already belong in the task brief. The Progress Note should record session delta, not duplicate stable context.
 
-## 3. Design Handoff and Resume
-Good handoff is not a long narrative. It is a restart procedure. `docs/en/session-memory-policy.md` defines the minimum `Resume Packet` as four items. In this chapter, that minimal packet is referred to as a `Restart Packet (Resume Packet)`:
+## 3. Design Handoff and Restart
+Good handoff is not a long narrative. It is a restart procedure. `docs/en/session-memory-policy.md` defines the minimum `Restart Packet (Resume Packet)` as four items. In this chapter, that minimal packet is also referred to as a `Restart Packet (Resume Packet)`:
 
 1. the task brief
 2. the latest Progress Note
@@ -139,7 +139,7 @@ Comparison points:
 
 ## Exercises
 1. Convert a GitHub issue into a task brief.
-2. Build a `Restart Packet (Resume Packet)` that starts from a `Progress Note` and includes the task brief and verify result.
+2. Build a `Restart Packet (Resume Packet)` that starts from a `Progress Note` and includes the task brief and latest verify result.
 
 ## Referenced Artifacts
 - `sample-repo/tasks/FEATURE-001-brief.md`
@@ -148,7 +148,7 @@ Comparison points:
 - `.github/ISSUE_TEMPLATE/task.yml`
 
 ## Source Notes / Further Reading
-- To revisit this chapter quickly, start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, and `docs/en/session-memory-policy.md`. These three artifacts show the boundary between stable task context and mutable session context. The policy names this minimal restart artifact a `Resume Packet`, while this chapter refers to it as a `Restart Packet (Resume Packet)`.
+- To revisit this chapter quickly, start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, and `docs/en/session-memory-policy.md`. These three artifacts show the boundary between stable task context and mutable session context. The policy uses `Restart Packet (Resume Packet)` as the term for this minimal restart artifact, and this chapter uses the same term.
 - For the backmatter navigation path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH07 Task Context and Session Memory` and `manuscript-en/backmatter/01-reading-guide.md` under `## Context and Repo Design`.
 
 ## Chapter Summary


### PR DESCRIPTION
## Summary
- align EN CH07 with the current `Restart Packet (Resume Packet)` wording
- make the policy term `Resume Packet` explicit where the chapter references `docs/en/session-memory-policy.md`
- keep the slice limited to the English chapter text

## Testing
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh
