### PR TITLE
Normalize sample-repo glossary prose

### DIFF
--- a/sample-repo/README.md
+++ b/sample-repo/README.md
@@ -2,7 +2,7 @@
 
 本ディレクトリは、本書全体で使うケーススタディです。題材は、社内サポートチームが問い合わせチケットをさばく小さな Python サービス `support-hub` です。規模は小さいですが、曖昧要求の仕様化、repo context の設計、task handoff、verification harness までを 1 つの題材で通して扱えるだけの現場感を持たせています。
 
-本書では `docs/seed-issues.md` の 4 件を貫通ケースとして繰り返し扱います。目的は機能を増やすことではありません。AIエージェントが「答えられる」状態から「仕事を完了できる」状態へ進むとき、Prompt Contract、context pack、verification harness、Approval Boundary、Restart Packet のような artifact がどう連動するかを追うことです。
+本書では `docs/seed-issues.md` の 4 件を貫通ケースとして繰り返し扱います。目的は機能を増やすことではありません。AIエージェントが「答えられる」状態から「仕事を完了できる」状態へ進むとき、Prompt Contract、context pack、verification harness、approval boundary、restart packet のような artifact がどう連動するかを追うことです。
 
 ## この題材の現場
 - 一次受け担当は、新規 ticket を読み、重複や緊急度を見て triage する
@@ -17,7 +17,7 @@
 |---|---|---|---|
 | `BUG-001` | ステータス更新後に旧状態が見え、二重対応が起きうる | CH01, CH02, CH09 | 範囲を閉じた bugfix を prompt と harness で完了へ持ち込む感覚をつかむ |
 | `FEATURE-001` | 既存 ticket を見つけにくく、要求も曖昧 | CH01, CH03, CH04, CH05-CH08, CH10 | 曖昧要求を spec、context、verify に変える流れを理解する |
-| `FEATURE-002` | assignee と監査ログの整理が長時間化しやすい | CH01, CH07, CH11, CH12 | long-running task を feature list、Restart Packet、owner と merge order で扱う |
+| `FEATURE-002` | assignee と監査ログの整理が長時間化しやすい | CH01, CH07, CH11, CH12 | long-running task を feature list、restart packet、owner と merge order で扱う |
 | `HARNESS-001` | verify と証跡が弱く、変更を安心してレビューできない | CH01, CH09, CH10, CH12 | verification harness と evidence / approval の必要性を理解する |
 
 各ケースの chapter guide と中心 artifact は `docs/seed-issues.md` にまとめてある。後続章で「なぜ今このケースを見るのか」を確認したくなったら、まずここへ戻る。

--- a/sample-repo/context-packs/ticket-search.md
+++ b/sample-repo/context-packs/ticket-search.md
@@ -33,7 +33,7 @@
 - 最新の `python -m unittest discover -s tests -v` 結果
 - `tests/test_ticket_search.py` の期待値
 - 直近の `tasks/FEATURE-001-progress.md`
-- public contract や scope を越える変更が Approval Boundary に当たらないか
+- public contract や scope を越える変更が approval boundary に当たらないか
 
 ## Approval Boundary
 - `list_tickets` の既存 public contract を変える
@@ -50,4 +50,4 @@
 - docs、tests、実装が同じ挙動を説明している
 - verify が通る
 - `Progress Note` が更新されている
-- unresolved な Approval Boundary が残っていない
+- unresolved な approval boundary が残っていない

--- a/sample-repo/docs/repo-map.md
+++ b/sample-repo/docs/repo-map.md
@@ -38,5 +38,5 @@
 ## Update Guide
 - 振る舞い変更時は code だけでなく docs / tests / task artifacts を同時に更新する
 - 変更対象が `service.py` なら、関連する acceptance criteria と `Progress Note` を確認する
-- 中断や handoff がある場合は、task brief、最新 `Progress Note`、最新 verify、再開時に読むファイル一覧が Restart Packet として揃っている状態にする
-- public contract や外部依存を変える場合は Approval Boundary を越える前に止まる
+- 中断や handoff がある場合は、task brief、最新 `Progress Note`、最新 verify、再開時に読むファイル一覧が restart packet として揃っている状態にする
+- public contract や外部依存を変える場合は approval boundary を越える前に止まる

--- a/sample-repo/tasks/BUG-001-brief.md
+++ b/sample-repo/tasks/BUG-001-brief.md
@@ -31,7 +31,7 @@
 
 ## Constraints
 - UI 層は扱わない
-- public contract を変える場合は Approval Boundary を越える前に止まる
+- public contract を変える場合は approval boundary を越える前に止まる
 - verify、docs、task artifact の更新境界を先に固定する
 
 ## Acceptance Criteria

--- a/sample-repo/tasks/FEATURE-001-brief.md
+++ b/sample-repo/tasks/FEATURE-001-brief.md
@@ -30,7 +30,7 @@
 - `list_tickets` の既存 public contract は変更しない
 - ranking、typo correction、外部検索エンジンは今回扱わない
 - docs、tests、task artifact を同時に更新する
-- public contract や scope を広げる変更は Approval Boundary で止める
+- public contract や scope を広げる変更は approval boundary で止める
 
 ## Acceptance Criteria
 - title / description / tags の部分一致


### PR DESCRIPTION
## Summary
- align reader-facing prose in `sample-repo` with the canonical glossary casing
- keep headings and artifact names as-is, but normalize prose references to `restart packet` and `approval boundary`
- update README, repo map, task briefs, and the ticket-search context pack together to avoid terminology drift

## Verification
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh
