### PR TITLE
Normalize prompt and source-note prose terms

### DIFF
--- a/manuscript/backmatter/00-source-notes.md
+++ b/manuscript/backmatter/00-source-notes.md
@@ -53,7 +53,7 @@
 
 ### CH07 Task Context と Session Memory
 
-- 最初に信頼するのは `sample-repo/tasks/FEATURE-001-brief.md`、`sample-repo/tasks/FEATURE-001-progress.md`、`docs/session-memory-policy.md`、`.github/ISSUE_TEMPLATE/task.yml` である。ポリシーの `Restart Packet（Resume Packet）` を、本書でも `Restart Packet（Resume Packet）` として扱い、最新 verify とセットで読む。
+- 最初に信頼するのは `sample-repo/tasks/FEATURE-001-brief.md`、`sample-repo/tasks/FEATURE-001-progress.md`、`docs/session-memory-policy.md`、`.github/ISSUE_TEMPLATE/task.yml` である。ポリシーの `Restart Packet（Resume Packet）` を、本書でも `restart packet（Resume Packet）` として扱い、最新 verify とセットで読む。
 - 外部 source を足すなら、[OpenAI Codex: AGENTS.md](https://developers.openai.com/codex/guides/agents-md) を先に見て、[Anthropic: Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) は補助線として使う。組織の issue tracker / handoff / change log ルールを優先し、古い summary や chat log を session memory の正本にしない。
 
 ### CH08 Skills と Context Pack を再利用する

--- a/manuscript/figures/figure-plan.md
+++ b/manuscript/figures/figure-plan.md
@@ -6,8 +6,8 @@
 |---|---|---|---|---|---|
 | `fig-01` | CH01 | 「Prompt Engineering / Context Engineering / Harness Engineering の対応表」の直後 | Prompt / Context / Harness は、誤答・忘却・破壊/停止という failure mode を減らす順に積み上がる。 | 書店での立ち読みでも本書の promise と progression が 1 枚で伝わる。 | `fig-01-maturity-model.mmd` |
 | `fig-02` | CH05 | 「永続・タスク・セッション・ツールコンテキスト」の直後 | Context は永続、タスク、セッション、ツールの 4 種類に分かれ、鮮度と更新責任が異なる。 | Context Engineering を「情報を増やす話」ではなく「寿命を分ける話」として理解しやすくする。 | `fig-02-context-classes.mmd` |
-| `fig-03` | CH07 | 「セッション再開時の最低入力」の直後 | 再開時は repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。 | repo / task / session の関係と `Restart Packet（Resume Packet）` の読み順を 1 枚で再確認できる。 | `fig-03-resume-packet.mmd` |
+| `fig-03` | CH07 | 「セッション再開時の最低入力」の直後 | 再開時は repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。 | repo / task / session の関係と `restart packet（Resume Packet）` の読み順を 1 枚で再確認できる。 | `fig-03-resume-packet.mmd` |
 | `fig-04` | CH09 | 「single-agent harness の全体像」の直後 | single-agent harness は init、boundary、permission、verify、exit、report を 1 つの実行枠にまとめる。 | Harness Engineering が prompt の言い換えではなく、開始条件と終了条件の設計だと分かる。 | `fig-04-single-agent-harness.mmd` |
 | `fig-05` | CH10 | 「lint / typecheck / unit / e2e の順序」の直後 | verification harness は failing test、local verify、CI、evidence、approval を順序付きでつなぐ。 | verify を単発コマンドではなく review-ready に向かう pipeline として読める。 | `fig-05-verification-pipeline.mmd` |
-| `fig-06` | CH11 | 「planner / coder / reviewer の分離」の直後 | long-running task は feature list、`Restart Packet（Resume Packet）`、`approval boundary`、role 分担が揃って初めて安全に multi-agent へ分割できる。 | long-running task と multi-agent の関係を責務図として再参照できる。 | `fig-06-long-running-multi-agent.mmd` |
+| `fig-06` | CH11 | 「planner / coder / reviewer の分離」の直後 | long-running task は feature list、`restart packet（Resume Packet）`、`approval boundary`、role 分担が揃って初めて安全に multi-agent へ分割できる。 | long-running task と multi-agent の関係を責務図として再参照できる。 | `fig-06-long-running-multi-agent.mmd` |
 | `fig-07` | CH12 | 「人間が残す責務」の直後 | operating model は Human と Agent の責務、review budget、metrics、cleanup cadence を循環させて保つ。 | チーム導入を「モデル選定」ではなく「責務と cadence の設計」として理解しやすくする。 | `fig-07-operating-model.mmd` |

--- a/manuscript/part-01-prompt/ch04-prompt-evals.md
+++ b/manuscript/part-01-prompt/ch04-prompt-evals.md
@@ -171,7 +171,7 @@ good:
 | Scope | ranking を勝手に追加する | Non-goals を保つ |
 | Missing Information | 曖昧な要件を補完してしまう | 不足情報を明示する |
 | Artifacts | docs 更新が抜ける | spec / acceptance / ADR を列挙する |
-| Approval Boundary | 承認が必要な操作へ自律実行で進む | approval gate と停止条件を返す |
+| approval boundary | 承認が必要な操作へ自律実行で進む | approval gate と停止条件を返す |
 
 この worked example で重要なのは、prompt の良さを文章の雰囲気で語らないことだ。同じケースで比較し、何が改善し、何が未解決かを観点ごとに記録する。これが prompt evaluation を engineering discipline に変える。
 


### PR DESCRIPTION
## Summary
- align reader-facing prose in CH04, source notes, and figure plan with the canonical glossary casing
- normalize prose references to `restart packet` and `approval boundary` without changing artifact names
- keep this slice non-overlapping with PR #200

## Verification
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh
