### PR TITLE
Align restart protocol template labels

### DIFF
--- a/manuscript-en/appendices/app-c-harness-templates.md
+++ b/manuscript-en/appendices/app-c-harness-templates.md
@@ -33,7 +33,7 @@ The recommended flow has three stages.
 
 The template has three core parts.
 
-- `Restart Packet`: the minimum input that must exist before restart
+- `Restart Packet (Canonical Inputs)`: the minimum input that must exist before restart
 - `Restart Steps`: the read order and how to choose the next single work package
 - `Stop Conditions`: when missing information or ownership conflict should block restart
 

--- a/templates/en/restart-protocol.md
+++ b/templates/en/restart-protocol.md
@@ -1,6 +1,6 @@
 # Restart Protocol Template
 
-## Restart Packet
+## Restart Packet (Canonical Inputs)
 - Include the current plan or feature list.
 - Include the latest Progress Note.
 - Include the latest verify result.

--- a/templates/restart-protocol.md
+++ b/templates/restart-protocol.md
@@ -1,6 +1,6 @@
 # Restart Protocol Template
 
-## Restart Packet
+## Restart Packet (Canonical Inputs)
 - plan または feature list
 - 最新の Progress Note
 - 直近の verify 結果


### PR DESCRIPTION
## Summary
- align the restart-protocol template heading with the canonical sample-repo label
- mirror the same label in the English harness appendix

## Verification
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh
