### PR TITLE
Normalize fig-03 caption terms

### DIFF
--- a/manuscript-en/figures/fig-03-resume-packet.mmd
+++ b/manuscript-en/figures/fig-03-resume-packet.mmd
@@ -1,6 +1,6 @@
 %% title: fig-03 restart packet
 %% chapter: CH07
-%% caption: A Restart Packet (Resume Packet) reduces drift when you read downward from repo context to task brief, session memory, and live verify in that order.
+%% caption: A restart packet (Resume Packet) reduces drift when you read downward from repo context to task brief, session memory, and live verify in that order.
 flowchart TB
     A[Repo Context<br/>AGENTS / repo-map / architecture] --> B[Task Brief<br/>Goal / Scope / Inputs / Verification]
     B --> C[Session Memory<br/>Progress Note / open questions / next step]

--- a/manuscript/figures/fig-03-resume-packet.mmd
+++ b/manuscript/figures/fig-03-resume-packet.mmd
@@ -1,6 +1,6 @@
 %% title: fig-03 restart packet
 %% chapter: CH07
-%% caption: Restart Packet（Resume Packet）では、repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。
+%% caption: restart packet（Resume Packet）では、repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。
 flowchart TB
     A[Repo Context<br/>AGENTS / repo-map / architecture] --> B[Task Brief<br/>Goal / Scope / Inputs / Verification]
     B --> C[Session Memory<br/>Progress Note / open questions / next step]


### PR DESCRIPTION
## Summary
- normalize the fig-03 caption wording to glossary-consistent `restart packet`
- keep figure IDs and file names unchanged

## Verification
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh
