### PR TITLE
Normalize CH07 restart packet prose

### DIFF
--- a/manuscript-en/part-02-context/ch07-task-context-and-memory.md
+++ b/manuscript-en/part-02-context/ch07-task-context-and-memory.md
@@ -56,7 +56,7 @@ The purpose of this format is not to preserve every step of exploration. Its pur
 The most common mistake is to paste brief content into the Progress Note. Goal, constraints, and acceptance criteria already belong in the task brief. The Progress Note should record session delta, not duplicate stable context.
 
 ## 3. Design Handoff and Restart
-Good handoff is not a long narrative. It is a restart procedure. `docs/en/session-memory-policy.md` defines the minimum `restart packet (Resume Packet)` as four items. In this chapter, that minimal packet is also referred to as a `restart packet (Resume Packet)`:
+Good handoff is not a long narrative. It is a restart procedure. `docs/en/session-memory-policy.md` defines the "Minimum Input for a Restart Packet (Resume Packet)" as four items. In this chapter, that same minimal set is also referred to as a `restart packet (Resume Packet)`:
 
 1. the task brief
 2. the latest Progress Note
@@ -148,7 +148,7 @@ Comparison points:
 - `.github/ISSUE_TEMPLATE/task.yml`
 
 ## Source Notes / Further Reading
-- To revisit this chapter quickly, start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, and `docs/en/session-memory-policy.md`. These three artifacts show the boundary between stable task context and mutable session context. The policy uses `restart packet (Resume Packet)` as the term for this minimal restart artifact, and this chapter uses the same term.
+- To revisit this chapter quickly, start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, and `docs/en/session-memory-policy.md`. These three artifacts show the boundary between stable task context and mutable session context. The policy refers to this minimal restart artifact as a `Restart Packet`, and this chapter discusses the same concept as a `restart packet (Resume Packet)`.
 - For the backmatter navigation path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH07 Task Context and Session Memory` and `manuscript-en/backmatter/01-reading-guide.md` under `## Context and Repo Design`.
 
 ## Chapter Summary

--- a/manuscript/part-02-context/ch07-task-context-and-memory.md
+++ b/manuscript/part-02-context/ch07-task-context-and-memory.md
@@ -42,7 +42,7 @@ task brief が stable な task context だとすると、`Progress Note` は mut
 `Progress Note` がないと、AI agent は「前回どこまでやったか」を chat history に依存する。これは session を跨いだ瞬間に壊れる。Session Memory は、会話ではなく artifact に残す必要がある。
 
 ### 3. handoff と restart の設計
-handoff で必要なのは、全文サマリーではなく、再開手順である。`docs/session-memory-policy.md` は「Resume Packet の最低入力」として、task brief、最新 `Progress Note`、最新 verify 結果、再開時に読むべきファイル一覧の 4 点を定義している。本章では、この最小 packet を `restart packet（Resume Packet）` と呼ぶ。これは最小だが十分である。
+handoff で必要なのは、全文サマリーではなく、再開手順である。`docs/session-memory-policy.md` は「Restart Packet（Resume Packet）の最低入力」として、task brief、最新 `Progress Note`、最新 verify 結果、再開時に読むべきファイル一覧の 4 点を定義している。本章では、この最小 packet を `restart packet（Resume Packet）` と呼ぶ。これは最小だが十分である。
 
 `FEATURE-001` を例にすると、途中で作業者が交代しても、次の担当者は `FEATURE-001-brief.md` を読んで scope を確認し、`FEATURE-001-progress.md` で前回の `Decided` と `Open Questions` を見て、最後に verify を回せば再開できる。逆に「前回はだいたい検索仕様の話をしていた」程度の handoff では、どこまで確定したかが分からず、同じ議論をやり直すことになる。
 


### PR DESCRIPTION
## Summary
- normalize remaining CH07 reader-facing `restart packet` prose in the Japanese and English chapters
- keep the chapter heading intact while aligning body text, exercises, and source-note guidance with the glossary form

## Testing
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh
