### PR TITLE
[codex] Normalize restart packet terms in backmatter

### DIFF
--- a/manuscript/backmatter/00-source-notes.md
+++ b/manuscript/backmatter/00-source-notes.md
@@ -53,7 +53,7 @@
 
 ### CH07 Task Context と Session Memory
 
-- 最初に信頼するのは `sample-repo/tasks/FEATURE-001-brief.md`、`sample-repo/tasks/FEATURE-001-progress.md`、`docs/session-memory-policy.md`、`.github/ISSUE_TEMPLATE/task.yml` である。ポリシーの `Restart Packet（Resume Packet）` を、本書でも `restart packet（Resume Packet）` として扱い、最新 verify とセットで読む。
+- 最初に信頼するのは `sample-repo/tasks/FEATURE-001-brief.md`、`sample-repo/tasks/FEATURE-001-progress.md`、`docs/session-memory-policy.md`、`.github/ISSUE_TEMPLATE/task.yml` である。ポリシーの `Restart Packet（Resume Packet）` に対応する最小 artifact を、本書では `restart packet` として扱い、最新 verify とセットで読む。
 - 外部 source を足すなら、[OpenAI Codex: AGENTS.md](https://developers.openai.com/codex/guides/agents-md) を先に見て、[Anthropic: Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) は補助線として使う。組織の issue tracker / handoff / change log ルールを優先し、古い summary や chat log を session memory の正本にしない。
 
 ### CH08 Skills と Context Pack を再利用する

--- a/manuscript/backmatter/01-読書案内.md
+++ b/manuscript/backmatter/01-読書案内.md
@@ -37,7 +37,7 @@
 | A2A の仕様、あるいは同等の agent handoff 仕様 | agent 間の task 移譲、handoff、状態共有の考え方 | CH07, CH11 |
 | GitHub / 利用中 VCS platform の official docs | issue、PR、review、branch protection、artifact 追跡 | CH03, CH06, CH10 |
 | 組織内の repo-map、architecture、coding standards | repo context の正本化、ownership の明確化 | CH06 |
-| handoff / incident / change log の組織ルール | session memory、`restart packet（Resume Packet）`、handoff contract、approval boundary | CH07, CH11 |
+| handoff / incident / change log の組織ルール | session memory、`restart packet`、handoff contract、approval boundary | CH07, CH11 |
 
 ## 検証・信頼性・運用
 

--- a/manuscript/backmatter/03-図表一覧方針.md
+++ b/manuscript/backmatter/03-図表一覧方針.md
@@ -13,7 +13,7 @@
 - 図 ID、対象章、caption、first mention は `manuscript/figures/figure-plan.md` を正本にする
 - 図一覧では「図から何を理解してほしいか」が 1 行で分かる caption を維持する
 - 1 図 = 1 主メッセージを守り、組版後に図番号だけを差し替える
-- caption と first mention は glossary / chapter wording に合わせ、`restart packet（Resume Packet）`、`Progress Note`、`approval boundary` の表記 drift を残さない
+- caption と first mention は glossary / chapter wording に合わせ、`restart packet`、`Progress Note`、`approval boundary` の表記 drift を残さない
 
 ## 現時点の図 seed
 
@@ -40,7 +40,7 @@
 | CH01 | 単発で当たることと、仕事が完了することは違う | plausible output と完了した仕事の差を示す |
 | CH02 | prompt は命令文ではなく入出力契約 | Prompt Contract の要素と欠落時の failure を示す |
 | CH04 | 良い prompt は評価できる | prompt / context / harness evaluation の境界を示す |
-| CH07 | restart packet（Resume Packet）最小形 | 再開時に最低限必要な要素を示す |
+| CH07 | restart packet 最小形 | 再開時に最低限必要な要素を示す |
 | CH09 | Single-Agent Harness フロー | init から report までの工程を縮約する |
 | CH10 | Verification Pipeline | failing test から approval までの順序を示す |
 | CH11 | Long-running / Multi-agent 判定カード | single-agent と multi-agent の分岐条件を示す |

--- a/manuscript/figures/fig-03-resume-packet.mmd
+++ b/manuscript/figures/fig-03-resume-packet.mmd
@@ -1,8 +1,8 @@
 %% title: fig-03 restart packet
 %% chapter: CH07
-%% caption: restart packet（Resume Packet）では、repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。
+%% caption: restart packet では、repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。
 flowchart TB
     A[Repo Context<br/>AGENTS / repo-map / architecture] --> B[Task Brief<br/>Goal / Scope / Inputs / Verification]
     B --> C[Session Memory<br/>Progress Note / open questions / next step]
     C --> D[Latest Verify<br/>live result]
-    D --> E[Restart Packet<br/>reopen file list と次の 1 手]
+    D --> E[restart packet<br/>reopen file list と次の 1 手]

--- a/manuscript/figures/figure-plan.md
+++ b/manuscript/figures/figure-plan.md
@@ -6,8 +6,8 @@
 |---|---|---|---|---|---|
 | `fig-01` | CH01 | 「Prompt Engineering / Context Engineering / Harness Engineering の対応表」の直後 | Prompt / Context / Harness は、誤答・忘却・破壊/停止という failure mode を減らす順に積み上がる。 | 書店での立ち読みでも本書の promise と progression が 1 枚で伝わる。 | `fig-01-maturity-model.mmd` |
 | `fig-02` | CH05 | 「永続・タスク・セッション・ツールコンテキスト」の直後 | Context は永続、タスク、セッション、ツールの 4 種類に分かれ、鮮度と更新責任が異なる。 | Context Engineering を「情報を増やす話」ではなく「寿命を分ける話」として理解しやすくする。 | `fig-02-context-classes.mmd` |
-| `fig-03` | CH07 | 「セッション再開時の最低入力」の直後 | 再開時は repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。 | repo / task / session の関係と `restart packet（Resume Packet）` の読み順を 1 枚で再確認できる。 | `fig-03-resume-packet.mmd` |
+| `fig-03` | CH07 | 「セッション再開時の最低入力」の直後 | 再開時は repo context から task brief、session memory、live verify へ降りる順で読むと drift が減る。 | repo / task / session の関係と `restart packet` の読み順を 1 枚で再確認できる。 | `fig-03-resume-packet.mmd` |
 | `fig-04` | CH09 | 「single-agent harness の全体像」の直後 | single-agent harness は init、boundary、permission、verify、exit、report を 1 つの実行枠にまとめる。 | Harness Engineering が prompt の言い換えではなく、開始条件と終了条件の設計だと分かる。 | `fig-04-single-agent-harness.mmd` |
 | `fig-05` | CH10 | 「lint / typecheck / unit / e2e の順序」の直後 | verification harness は failing test、local verify、CI、evidence、approval を順序付きでつなぐ。 | verify を単発コマンドではなく review-ready に向かう pipeline として読める。 | `fig-05-verification-pipeline.mmd` |
-| `fig-06` | CH11 | 「planner / coder / reviewer の分離」の直後 | long-running task は feature list、`restart packet（Resume Packet）`、`approval boundary`、role 分担が揃って初めて安全に multi-agent へ分割できる。 | long-running task と multi-agent の関係を責務図として再参照できる。 | `fig-06-long-running-multi-agent.mmd` |
+| `fig-06` | CH11 | 「planner / coder / reviewer の分離」の直後 | long-running task は feature list、`restart packet`、`approval boundary`、role 分担が揃って初めて安全に multi-agent へ分割できる。 | long-running task と multi-agent の関係を責務図として再参照できる。 | `fig-06-long-running-multi-agent.mmd` |
 | `fig-07` | CH12 | 「人間が残す責務」の直後 | operating model は Human と Agent の責務、review budget、metrics、cleanup cadence を循環させて保つ。 | チーム導入を「モデル選定」ではなく「責務と cadence の設計」として理解しやすくする。 | `fig-07-operating-model.mmd` |


### PR DESCRIPTION
## What changed
- normalize remaining `restart packet（Resume Packet）` prose in WP-05 support files to glossary-aligned `restart packet`
- update `fig-03` caption and node label to match the same wording
- keep file names and figure IDs unchanged

## Why
WP-05 closeout audit found a small but non-trivial terminology drift across backmatter and figure support. The canonical glossary term is `restart packet`, while these reader-facing support files still carried mixed wording.

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
