### PR TITLE
[codex] Normalize canonical input prose

### DIFF
--- a/manuscript/appendices/app-c-Harness-テンプレート集.md
+++ b/manuscript/appendices/app-c-Harness-テンプレート集.md
@@ -26,7 +26,7 @@ template の中核は 3 つある。
 - `Restart Steps`: 読み順と次の 1 手の決め方
 - `Stop Conditions`: 情報不足や衝突の疑いがあるときに止まる条件
 
-`sample-repo/docs/harness/restart-protocol.md` では、plan、feature list、最新 `Progress Note`、verify evidence、open questions を restart packet（Canonical Inputs）として定義している。restart protocol がないまま multi-agent を始めると、役割分担より先に state が壊れる。
+`sample-repo/docs/harness/restart-protocol.md` では、plan、feature list、最新 `Progress Note`、verify evidence、open questions から成る `restart packet` を定義している。restart protocol がないまま multi-agent を始めると、役割分担より先に state が壊れる。
 
 ## 3. Permission Policy Template
 

--- a/manuscript/backmatter/00-source-notes.md
+++ b/manuscript/backmatter/00-source-notes.md
@@ -73,7 +73,7 @@
 
 ### CH11 Long-running Task と Multi-agent
 
-- 最初に信頼するのは `sample-repo/docs/harness/feature-list.md`、`sample-repo/docs/harness/restart-protocol.md`、`sample-repo/docs/harness/multi-agent-playbook.md`、`sample-repo/tasks/FEATURE-002-plan.md` である。multi-agent は role split と restart packet（Canonical Inputs）が揃って初めて扱う。
+- 最初に信頼するのは `sample-repo/docs/harness/feature-list.md`、`sample-repo/docs/harness/restart-protocol.md`、`sample-repo/docs/harness/multi-agent-playbook.md`、`sample-repo/tasks/FEATURE-002-plan.md` である。multi-agent は role split と `restart packet` が揃って初めて扱う。
 - 外部 source を足すなら、[OpenAI Codex: Subagents](https://developers.openai.com/codex/subagents)、[A2A Protocol specification](https://a2a-protocol.org/latest/specification/)、[Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) を優先する。並列化の議論を、write scope と handoff artifact から切り離さない。
 
 ### CH12 運用モデルと組織導入


### PR DESCRIPTION
## What changed
- normalize remaining reader-facing prose that still referred to `restart packet（Canonical Inputs）`
- keep the template heading `Restart Packet (Canonical Inputs)` unchanged where it names the artifact section

## Why
After `#210`, WP-05 still had one small terminology drift in appendix C and source notes. The glossary term is `restart packet`; the parenthetical label belongs to the template heading, not to general prose.

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
