### PR TITLE
[codex] Sync release plan with rewrite closeout

### DIFF
--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -21,12 +21,12 @@ Status: completed
 CH09-CH12 を執筆し、verification / restart / operating model を固める。
 
 ## M4 Polish
-Status: active
+Status: completed
 
-appendix、glossary、cross-reference、technical pass、editorial cleanup を継続する。
+appendix、glossary、cross-reference、technical pass、editorial cleanup を closeout 監査まで完了した。
 
 ## Current Focus
 
-- review で見つかった drift を issue 単位で修正する
-- 日本語版と英語版の onboarding / parity docs を current state に保つ
-- verify 出力、cross-reference、support artifact の terminology drift を小さく解消する
+- rewrite umbrella を再利用せず、focused follow-up issue / PR として maintenance を進める
+- 日本語版と英語版の parity docs は drift が見つかったときだけ小さく更新する
+- verify 出力、cross-reference、support artifact の terminology drift は periodic audit で点検する


### PR DESCRIPTION
## What Changed
- marked `M4 Polish` as completed in `docs/release-plan.md`
- rewrote `Current Focus` so it reflects post-rewrite maintenance instead of active umbrella execution
- aligned the release plan with the closed state of rewrite umbrella issue `#153` and closed work-package issues `#154`-`#159`

## Why
The rewrite umbrella and all work packages are closed, but `docs/release-plan.md` still described `M4 Polish` as active. This PR synchronizes the release plan with the actual closeout state.

Closes #214

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`
