### PR TITLE
[codex] Clarify CH07 restart packet wording

### DIFF
--- a/manuscript-en/part-02-context/ch07-task-context-and-memory.md
+++ b/manuscript-en/part-02-context/ch07-task-context-and-memory.md
@@ -148,7 +148,7 @@ Comparison points:
 - `.github/ISSUE_TEMPLATE/task.yml`
 
 ## Source Notes / Further Reading
-- To revisit this chapter quickly, start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, and `docs/en/session-memory-policy.md`. These three artifacts show the boundary between stable task context and mutable session context. The policy refers to this minimal restart artifact as a `Restart Packet`, and this chapter discusses the same concept as a `restart packet (Resume Packet)`.
+- To revisit this chapter quickly, start with `sample-repo/tasks/FEATURE-001-brief.md`, `sample-repo/tasks/FEATURE-001-progress.md`, and `docs/en/session-memory-policy.md`. These three artifacts show the boundary between stable task context and mutable session context. The policy refers to this minimal restart artifact as a `Restart Packet (Resume Packet)`, and this chapter discusses the same concept as a `restart packet (Resume Packet)`.
 - For the backmatter navigation path, see `manuscript-en/backmatter/00-source-notes.md` under `### CH07 Task Context and Session Memory` and `manuscript-en/backmatter/01-reading-guide.md` under `## Context and Repo Design`.
 
 ## Chapter Summary

--- a/manuscript/part-02-context/ch07-task-context-and-memory.md
+++ b/manuscript/part-02-context/ch07-task-context-and-memory.md
@@ -119,13 +119,13 @@ Acceptance Criteria、Verification を確認する。
 - `sample-repo/tasks/FEATURE-001-progress.md`
   session memory の実例として読む。`Decided` と `Open Questions` をどう分離しているかを確認する。
 - `docs/session-memory-policy.md`
-  `Progress Note` の必須項目と `Resume Packet` の最低入力を確認する。本章ではこれを `restart packet（Resume Packet）` として扱い、本文の再開手順と照らし合わせて読む。
+  `Progress Note` の必須項目と `Restart Packet（Resume Packet）` の最低入力を確認する。本章ではこれを `restart packet（Resume Packet）` として扱い、本文の再開手順と照らし合わせて読む。
 - `.github/ISSUE_TEMPLATE/task.yml`
   GitHub issue 側の最小入力を確認する。brief で何を補っているかを比較する起点になる。
 
 
 ## Source Notes / Further Reading
-- この章を探し直すときは、まず `sample-repo/tasks/FEATURE-001-brief.md`、`sample-repo/tasks/FEATURE-001-progress.md`、`docs/session-memory-policy.md` を正本として見る。ポリシーでは `Resume Packet` と呼ぶ最小 packet を、本章では `restart packet（Resume Packet）` として扱う。summary だけでなく最新 verify とセットで読む。
+- この章を探し直すときは、まず `sample-repo/tasks/FEATURE-001-brief.md`、`sample-repo/tasks/FEATURE-001-progress.md`、`docs/session-memory-policy.md` を正本として見る。ポリシーでは `Restart Packet（Resume Packet）` と呼ぶ最小 packet を、本章では `restart packet（Resume Packet）` として扱う。summary だけでなく最新 verify とセットで読む。
 - 次の一歩は `manuscript/backmatter/00-source-notes.md` の「CH07 Task Context と Session Memory」と `manuscript/backmatter/01-読書案内.md` の「Context と repo 設計」を参照する。
 
 ## 章末まとめ


### PR DESCRIPTION
## What Changed
- clarified that the CH07 policy reference points to `Restart Packet（Resume Packet）` / `Restart Packet (Resume Packet)` when quoting the policy label
- kept the chapter-level reader-facing term as `restart packet（Resume Packet）` / `restart packet (Resume Packet)`
- synchronized the Japanese and English CH07 wording so the distinction between policy label and chapter term is explicit in both editions

## Why
After the rewrite closeout, CH07 still mixed the policy label and the chapter term in a few places, which made the intended distinction harder to scan.

Closes #217

## Validation
- `git diff --check`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- `./scripts/verify-sample.sh`
