### PR TITLE
[codex] Harden JP backmatter source guidance

### DIFF
--- a/manuscript/backmatter/00-source-notes.md
+++ b/manuscript/backmatter/00-source-notes.md
@@ -44,39 +44,39 @@
 ### CH05 Context Engineering の基礎
 
 - 最初に信頼するのは `docs/context-model.md`、`docs/context-budget.md`、`docs/context-risk-register.md` である。Context Engineering は情報量ではなく、寿命、更新責任、毒性の管理として読む。
-- 外部 source を足すなら、[OpenAI Codex: AGENTS.md](https://developers.openai.com/codex/guides/agents-md)、[OpenAI Codex: Skills](https://developers.openai.com/codex/skills)、[Anthropic: Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) を優先する。長い prompt の寄せ集めや context window の広さだけで context design を説明しない。
+- 外部 source を足すなら、利用中ツールの context window、instruction layering、workspace access の公式 docs を優先する。長い prompt の寄せ集めは context design の説明にならない。
 
 ### CH06 Repo Context を設計する
 
 - 最初に信頼するのは `AGENTS.md`、`manuscript/AGENTS.md`、`sample-repo/AGENTS.md`、`sample-repo/docs/repo-map.md`、`sample-repo/docs/architecture.md`、`sample-repo/docs/coding-standards.md` である。repo-map は索引、architecture は設計理由として分けて読む。
-- 外部 source を足すなら、[OpenAI Codex: AGENTS.md](https://developers.openai.com/codex/guides/agents-md)、[OpenAI Codex: Hooks](https://developers.openai.com/codex/hooks)、[GitHub Coding Agent: Create custom agents](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents) を優先する。repo の責務分離は一般論より、instruction layering と managed policy の実運用で判断する方が速い。
+- 外部 source を足すなら、利用中 VCS、CI、package manager の公式 docs を優先する。repo の責務分離は一般論より実 repo の構成で判断する方が速い。
 
 ### CH07 Task Context と Session Memory
 
 - 最初に信頼するのは `sample-repo/tasks/FEATURE-001-brief.md`、`sample-repo/tasks/FEATURE-001-progress.md`、`docs/session-memory-policy.md`、`.github/ISSUE_TEMPLATE/task.yml` である。ポリシーの `Restart Packet（Resume Packet）` に対応する最小 artifact を、本書では `restart packet` として扱い、最新 verify とセットで読む。
-- 外部 source を足すなら、[OpenAI Codex: AGENTS.md](https://developers.openai.com/codex/guides/agents-md) を先に見て、[Anthropic: Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) は補助線として使う。組織の issue tracker / handoff / change log ルールを優先し、古い summary や chat log を session memory の正本にしない。
+- 外部 source を足すなら、組織の issue tracker / handoff / change log ルールを優先し、必要に応じて利用中 runtime の session / resume 関連 docs を参照する。古い summary や chat log を session memory の正本にしない。
 
 ### CH08 Skills と Context Pack を再利用する
 
 - 最初に信頼するのは `.agents/skills/draft-chapter/SKILL.md`、`.agents/skills/review-chapter/SKILL.md`、`sample-repo/.agents/skills/issue-to-plan/SKILL.md`、`sample-repo/.agents/skills/verification/SKILL.md`、`sample-repo/context-packs/ticket-search.md` である。skill は再利用 workflow の契約、context pack は task ごとの最小入力として読む。
-- 外部 source を足すなら、[OpenAI Codex: Skills](https://developers.openai.com/codex/skills)、[OpenAI Codex: Subagents](https://developers.openai.com/codex/subagents)、[Google ADK: Skills](https://adk.dev/skills/) を優先する。フレームワーク名だけで再利用設計を説明しない。
+- 外部 source を足すなら、利用中 agent runtime の公式 skill / instruction docs を優先する。フレームワーク名だけで再利用設計を説明しない。
 
 ### CH09 Harness Engineering の基礎
 
 - 最初に信頼するのは `scripts/init.sh`、`scripts/verify-sample.sh`、`sample-repo/docs/harness/single-agent-runbook.md`、`sample-repo/docs/harness/permission-policy.md`、`sample-repo/docs/harness/done-criteria.md` である。single-agent harness は prompt の言い換えではなく、開始条件と終了条件の束である。
-- 外部 source を足すなら、[OpenAI Codex: Hooks](https://developers.openai.com/codex/hooks)、[OpenAI: New tools for building agents](https://openai.com/index/new-tools-for-building-agents/)、[Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) を優先する。権限境界は agent の印象論ではなく、実行環境の仕様で決める。
+- 外部 source を足すなら、shell、CI runner、permission model の公式 docs を優先する。権限境界は agent の印象論ではなく、実行環境の仕様で決める。
 
 ### CH10 Verification Harness を作る
 
 - 最初に信頼するのは `.github/workflows/verify.yml`、`checklists/verification.md`、`sample-repo/tests/test_ticket_search.py`、`artifacts/evidence/README.md` である。verification harness は test、CI、evidence、approval の流れで読む。
-- 外部 source を足すなら、[OpenAI Agents SDK: Tracing](https://openai.github.io/openai-agents-python/tracing/)、[OpenAI Agents SDK: Guardrails](https://openai.github.io/openai-agents-python/guardrails/)、[OpenAI Agents SDK: Human in the Loop](https://openai.github.io/openai-agents-python/human_in_the_loop/) を優先する。green screenshot だけでは reviewer が再検証できない。
+- 外部 source を足すなら、利用中 test framework、CI、coverage tool の公式 docs を優先する。green screenshot だけでは reviewer が再検証できない。
 
 ### CH11 Long-running Task と Multi-agent
 
 - 最初に信頼するのは `sample-repo/docs/harness/feature-list.md`、`sample-repo/docs/harness/restart-protocol.md`、`sample-repo/docs/harness/multi-agent-playbook.md`、`sample-repo/tasks/FEATURE-002-plan.md` である。multi-agent は role split と `restart packet` が揃って初めて扱う。
-- 外部 source を足すなら、[OpenAI Codex: Subagents](https://developers.openai.com/codex/subagents)、[A2A Protocol specification](https://a2a-protocol.org/latest/specification/)、[Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) を優先する。並列化の議論を、write scope と handoff artifact から切り離さない。
+- 外部 source を足すなら、使っている orchestration tool や task queue の公式 docs を優先する。並列化の議論を、write scope と handoff artifact から切り離さない。
 
 ### CH12 運用モデルと組織導入
 
 - 最初に信頼するのは `docs/operating-model.md`、`docs/metrics.md`、`checklists/repo-hygiene.md`、`.github/pull_request_template.md` である。運用モデルは Lead / Operator / Reviewer、approval boundary、review budget、cadence、cleanup の組で読む。
-- 外部 source を足すなら、[OpenAI Agents SDK: Human in the Loop](https://openai.github.io/openai-agents-python/human_in_the_loop/)、[OpenAI Agents SDK: Guardrails](https://openai.github.io/openai-agents-python/guardrails/)、[GitHub Coding Agent: About coding agent](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent) を優先する。導入判断をモデル比較だけで閉じない。
+- 外部 source を足すなら、組織が採用する review policy、release policy、metrics definition の公式文書を優先する。導入判断をモデル比較だけで閉じない。

--- a/manuscript/backmatter/01-読書案内.md
+++ b/manuscript/backmatter/01-読書案内.md
@@ -23,8 +23,7 @@
 
 | source | 何を補強するか | 関連章 |
 |---|---|---|
-| OpenAI / Codex の official docs | Prompt Contract、tool use、agent 実行境界、eval 前提 | CH02, CH04 |
-| Anthropic の official docs | prompt 設計、tool use、agent 振る舞いの比較観点 | CH02, CH04 |
+| 利用中モデルの official prompting guide | Prompt Contract、制約設計、tool use の前提 | CH02, CH04 |
 | 利用中モデルの official eval docs | case 設計、rubric、version comparison | CH04 |
 | Michael Nygard の Architecture Decision Records (ADR) | 決定理由を短く残す書き方 | CH03 |
 | 組織内の product spec / acceptance criteria template | exploratory dialogue から実装準備ができた artifact へ落とす基準 | CH03 |
@@ -33,9 +32,8 @@
 
 | source | 何を補強するか | 関連章 |
 |---|---|---|
-| MCP の仕様と利用中 runtime の official docs | instruction layering、tool/resource 接続、context source の境界 | CH05, CH06, CH08 |
-| A2A の仕様、あるいは同等の agent handoff 仕様 | agent 間の task 移譲、handoff、状態共有の考え方 | CH07, CH11 |
-| GitHub / 利用中 VCS platform の official docs | issue、PR、review、branch protection、artifact 追跡 | CH03, CH06, CH10 |
+| 利用中 agent runtime の official docs | instruction layering、workspace access、session の持ち方 | CH05, CH06, CH07, CH08 |
+| 利用中 VCS / CI / package manager の official docs | issue、PR、review、branch protection、artifact 追跡 | CH03, CH06, CH10 |
 | 組織内の repo-map、architecture、coding standards | repo context の正本化、ownership の明確化 | CH06 |
 | handoff / incident / change log の組織ルール | session memory、`restart packet`、handoff contract、approval boundary | CH07, CH11 |
 
@@ -43,8 +41,8 @@
 
 | source | 何を補強するか | 関連章 |
 |---|---|---|
-| OpenAI / Codex の official docs | verify 境界、権限、resume、evidence の実装差分 | CH09, CH10, CH11, CH12 |
-| Google の SRE 関連 docs と書籍 | reliability、運用責務、service の考え方 | CH09, CH10, CH12 |
+| 利用中 test framework / CI / coverage tool の official docs | verify 境界、evidence、実行条件の差分 | CH09, CH10, CH11, CH12 |
+| Betsy Beyer ほか, *Site Reliability Engineering* | reliability、運用責務、service の考え方 | CH09, CH10, CH12 |
 | Betsy Beyer ほか, *The Site Reliability Workbook* | checklist、runbook、運用設計の実装寄りの進め方 | CH09, CH10, CH11, CH12 |
 | Nicole Forsgren, Jez Humble, Gene Kim, *Accelerate* | metrics、throughput、運用改善の見方 | CH10, CH12 |
 | 組織内の approval / permission policy | human approval gate、越権防止、監査性 | CH09, CH12 |


### PR DESCRIPTION
## Summary
- harden Japanese backmatter guidance against vendor-specific tool drift
- replace narrow vendor examples with durable category-level official-source guidance
- keep repo-local source-of-truth and chapter terminology intact

## Scope
- manuscript/backmatter/00-source-notes.md
- manuscript/backmatter/01-読書案内.md

## Verification
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh

## Related
- closes #221
