### PR TITLE
[codex] Align EN fig-03 caption with figure plan

### DIFF
--- a/manuscript-en/figures/fig-03-resume-packet.mmd
+++ b/manuscript-en/figures/fig-03-resume-packet.mmd
@@ -1,6 +1,6 @@
 %% title: fig-03 restart packet
 %% chapter: CH07
-%% caption: A restart packet (Resume Packet) reduces drift when you read downward from repo context to task brief, session memory, and live verify in that order.
+%% caption: To resume safely, read downward from repo context to task brief, session memory, and live verify in that order.
 flowchart TB
     A[Repo Context<br/>AGENTS / repo-map / architecture] --> B[Task Brief<br/>Goal / Scope / Inputs / Verification]
     B --> C[Session Memory<br/>Progress Note / open questions / next step]


### PR DESCRIPTION
## Summary
- align the English fig-03 source caption with the current figure plan wording
- keep the file name and figure ID unchanged

## Scope
- `manuscript-en/figures/fig-03-resume-packet.mmd`

## Verification
- git diff --check
- ./scripts/verify-book.sh
- ./scripts/verify-pages.sh
- ./scripts/verify-sample.sh

## Related
- closes #225
