### PR TITLE
[codex] Sync English context and harness guidance

### DIFF
--- a/artifacts/en/evidence/README.md
+++ b/artifacts/en/evidence/README.md
@@ -1,40 +1,75 @@
 # Evidence Bundle
 
-This directory defines the English counterpart for the evidence-bundle guidance used by the harness chapters. As part of a verification harness, an evidence bundle preserves what changed, what was checked, and what the reviewer should inspect.
+The place to preserve verification results for UI changes and other user-visible changes. As part of the verification harness, an evidence bundle keeps review material in a form that lets reviewers see what changed and what was checked.
+
+## Related Artifacts
+- verify log
+  - the log that shows the current-run command, timestamp, and result
+- trace
+  - the history that shows handoff, retry, and state transitions
+- evidence bundle
+  - the review-ready bundle that combines verify-log references, trace references, repro steps, and images
+
+Verify logs and traces may be included in an evidence bundle, but they are not the same thing. The bundle is the artifact formatted for review.
 
 ## When To Create
-
-- when a UI layout, interaction flow, or visible behavior changes
-- when the reviewer cannot judge the change from logs alone
-- when a long-running task needs one bundle for verify logs and review notes
+- when a UI appearance or interaction flow changes
+- when the reviewer cannot judge the diff without shared repro steps
+- when a long-running task needs verify-log and trace references bundled for review
 
 ## Recommended Layout
-
 ```text
 artifacts/evidence/<task-id>/<timestamp>/
   summary.md
   verify.log
   repro.md
+  trace.md        # only when needed
   before.png
   after.png
 ```
 
-> Note: Evidence bundles themselves must be created under `artifacts/evidence/...`. The `artifacts/en/evidence/` directory only contains the English guidance for those bundles.
+> Note: actual evidence bundles still live under `artifacts/evidence/...`. `artifacts/en/evidence/` holds the English guidance only.
+
+## Minimum Trace Reference Contract
+When a trace is cited in review or metrics, it must at least be possible to connect the following items.
+
+- task / work-package identifier
+- run timestamp or run identifier
+- owner / handoff information (when relevant)
+- retry / restart reason (when relevant)
+- verify reference (which current-run verify this trace belongs to)
+- evidence linkage (which bundle or PR summary cites it)
+- redaction / privacy note (when relevant)
+
+This contract does not exist to replace current-run verify with trace. It is the minimum reference information that lets a reviewer identify what the trace refers to.
 
 ## Minimum Contents
-
 - `summary.md`
   - what changed
-  - which verify commands were run
-  - what the reviewer should inspect
+  - which verify steps were run
+  - what the reviewer should look at
+  - the evidence timestamp
 - `verify.log`
-  - the commands that ran and the key output
+  - the current-run command and the key log lines
 - `repro.md`
   - the before / after confirmation steps
+- `trace.md`
+  - only when handoff, retry, or failure analysis history is needed
+  - if it is cited, it must satisfy the minimum trace reference contract
 - `before.png`, `after.png`
   - only when the change is UI-visible
 
-## Notes
+## Freshness Rule
+- the evidence bundle must point to current-run verify at review time
+- if an older verify log is reused, `summary.md` must explain why rerun was impossible and what the impact is
+- do not keep only stale screenshots or stale traces while skipping current-run verify
+- do not mistake a trace with no verify reference for current-run evidence
 
+## Redaction / Privacy
+- remove secrets, credentials, personal data, or internal identifiers before bundling
+- do not share raw logs that the reviewer does not need
+- if redaction affects judgment, explain that impact in `summary.md`
+
+## Notes
 - backend-only changes may not need screenshots; `summary.md` and `verify.log` can still be required
-- if no bundle is needed, the PR summary should state why
+- when no bundle is needed, state the reason briefly in the PR summary

--- a/checklists/en/verification.md
+++ b/checklists/en/verification.md
@@ -1,32 +1,35 @@
 # Verification Checklist
 
 ## Before Edit
-
 - Have you confirmed which behavior must be preserved in the spec, acceptance criteria, or task brief?
 - Have you decided whether a failing test should be added or updated first?
 - Have you identified the local verify command and the matching CI job before starting the change?
-- If an evidence bundle is required, can you state that requirement before editing?
+- If an evidence bundle is required, can you explain that requirement before editing?
+- Are you sure that a referenced trace or old log is not being treated as a substitute for current-run verify?
 
 ## During Change
-
 - Have you kept the diff inside the smallest practical work package?
-- Have you updated docs, brief, and Progress Note where needed?
+- Have you updated docs, the brief, and the `Progress Note` where needed?
 - Have you classified verify failures by failure mode?
-- Are the command and pass/fail result recorded as current-run evidence rather than remembered from an earlier run?
+- Have you recorded the verify command and pass / fail result as current-run information?
+- For a long-running task, have you organized the handoff or retry events that should be kept in a trace?
+- If you keep a trace, have you recorded the task / work-package id, run timestamp or run id, owner / handoff, and retry / restart reason?
 
 ## Before Review
-
 - Have you run local verify?
+- Does the verify log preserve the command, timestamp, and pass / fail result?
 - Can the same quality bar be enforced in CI, and can you explain any intentional difference?
-- If the change is UI-facing or user-visible, have you preserved an evidence bundle?
-- If evidence is not required, can you explain why?
+- If the change is UI-facing or otherwise user-visible, have you preserved an evidence bundle?
+- Does the evidence point to the current run?
 - Are `Changed Files`, `Verification`, and `Remaining Gaps` consistent with the current diff?
+- If a trace is cited in review, are the verify reference and evidence linkage explicit?
+- Have you checked whether traces or screenshots need redaction / privacy treatment?
+- If evidence is not required, can you explain why?
 - Have you called out the points that still require human approval?
 - If any check was skipped, is that decision recorded in `Remaining Gaps`?
 
 ## Stop Instead Of Merge
-
 - Does an unrelated verify failure remain unresolved?
-- Is required evidence missing for the current run?
+- Is current-run evidence missing even though the change requires it?
 - Do local verify and CI disagree without an explanation?
-- Are there changes that need approval before merge?
+- Are there changes that require approval before merge?

--- a/docs/en/context-budget.md
+++ b/docs/en/context-budget.md
@@ -21,6 +21,17 @@ A context budget is not just a limit on how much text an AI agent reads. It is t
 | re-fetch | Refresh information that goes stale quickly | test output, grep results, external search results, terminal logs | Prefer rerunning over keeping it resident in chat |
 | persist | Carry conclusions into the next session | task-brief decisions, `Next Step`, ADR conclusions | Promote to a repo artifact and avoid dependence on chat history |
 
+## Runtime Economics Notes
+
+- prompt caching
+  - supports lower transfer cost and latency for stable prefixes and repeatedly referenced artifacts
+  - a cache hit does not guarantee correctness or freshness, so source-of-truth choice, verify, and refresh decisions for external data still have to be made separately
+- server-side compaction / context editing
+  - supports lower context pressure by thinning older turns or lower-priority context on the server side
+  - even when the runtime helps `compact`, it does not remove the policy for `re-fetch`, redaction, or artifact sync
+
+These two mechanisms improve context economics, but they do not replace the design of keep verbatim / summarize / compact / re-fetch / persist. As with a long context window, lower transport cost or larger resident context does not eliminate source-of-truth design itself.
+
 ## Keep Verbatim
 
 - acceptance criteria
@@ -69,6 +80,7 @@ Refresh live context before trusting a summary when:
 - verify results came from an earlier session
 - the task stopped at an approval boundary
 - the prior reasoning depended on external data
+- even if prompt caching or compaction is working, freshness still cannot be delegated to the runtime
 
 ## Drop
 

--- a/docs/en/context-model.md
+++ b/docs/en/context-model.md
@@ -33,6 +33,8 @@ The goal is not to maximize the number of surfaces. The goal is to avoid mixing 
 - live tool output
   - The current behavior or exploration result. Grep output, test output, and verify logs should be treated as refreshable evidence, not as permanent resident context.
 
+Modern runtime mechanisms such as prompt caching and server-side compaction / context editing sit on top of this responsibility split. Caching lowers the resend cost of stable context, while compaction / context editing lowers pressure from live context. But the repo or team still has to decide which artifact is the source of truth, when refresh is required, and where redaction must happen.
+
 ## Rules
 
 1. Do not use the prompt itself as a substitute for context.

--- a/docs/en/metrics.md
+++ b/docs/en/metrics.md
@@ -46,11 +46,34 @@ These metrics are not for bragging about throughput. They exist to identify wher
 ## Observability Inputs
 
 - `trace coverage`
-  - shows whether long-running work and handoffs leave enough history for failure analysis
+  - shows whether traces that satisfy the minimum trace reference contract remain for work packages with long-running work, handoff, retry, or restart
 - `current-run verify availability`
   - shows whether reviewers can inspect the latest run directly
 - `retry concentration`
   - shows whether failure loops are clustering in one stage of the flow
+
+## Trace Coverage Definition
+
+- denominator
+  - the number of work packages that involve long-running work, handoff, retry, or restart and therefore require trace references
+- numerator
+  - the number of work packages whose trace records satisfy the required fields among task / work-package id, run timestamp or run id, owner / handoff, retry / restart reason, verify reference, evidence linkage, and redaction note
+
+Use the following rule to decide what counts as “required.”
+
+- always required
+  - task / work-package id
+  - run timestamp or run id (at least one of the two)
+  - verify reference
+  - evidence linkage
+- conditionally required
+  - owner / handoff: required when the work package includes a handoff. When there is no handoff, record the current owner, and use `N/A` only in workflows that do not use an owner concept at all
+  - retry / restart reason: required when retry or restart happened. Otherwise state `N/A`
+  - redaction note: required when any part was redacted. Otherwise state `none` or `N/A`
+
+Do not leave non-applicable fields blank or silently omit them. Use a non-applicable marker such as `N/A` or `none`. A work package only counts in the numerator when all always-required fields are present and conditionally required fields are present whenever the condition applies.
+
+Trace coverage here does not mean only “a trace file exists.” It also measures whether a reviewer can explain which verify run and which task the trace belongs to.
 
 ## Intervention Rules
 
@@ -69,5 +92,6 @@ These metrics are not for bragging about throughput. They exist to identify wher
 - Is the main cause of verify failure prompt, context, or harness design?
 - Is queue wait time caused mainly by reviewer wait, verify wait, or approval wait?
 - Is low trace coverage making failure analysis impossible?
+- If trace coverage is low, is the real gap missing trace, missing verify reference, or missing evidence linkage?
 - Is worsening repo hygiene slowing the next round of work?
 - Are stale drafts and stale docs increasing at the same time?

--- a/docs/en/operating-model.md
+++ b/docs/en/operating-model.md
@@ -26,6 +26,20 @@ A runtime can provide mechanisms such as background execution, hosted tools, and
 
 The runtime provides mechanisms, not policy. If that distinction becomes blurry, convenience features hide responsibility instead of removing it.
 
+## Deciding Between a Runtime-managed Loop and a Repo-owned Manual Harness
+
+Final review and merge always remain human-owned, and source-of-truth artifacts remain repo-owned. With that fixed, decide whether a runtime-managed loop is enough or whether a manual harness should stay explicit by using the table below.
+
+| Decision Factor | When a runtime-managed loop is enough | When a repo-owned manual harness is still required |
+|---|---|---|
+| human approval | there is no additional approval gate beyond final review | the team wants artifact-managed approval before, during, or after execution |
+| evidence / audit trail | runtime status and verify results are enough to explain the work | a custom evidence bundle or audit-oriented record must be preserved |
+| stop / resume logic | the run is linear and closes with simple retry and simple stop behavior | conditional stop / resume, handoff, or retry rules must be preserved explicitly |
+| source-of-truth maintenance | the task brief and done criteria stay fixed during the run | artifact sync, refresh policy, or owned files must stay explicit during the run |
+| review packaging | the reviewer can read the runtime surface as-is | `Changed Files`, `Verification`, and `Remaining Gaps` need custom packaging |
+
+The key test is not whether the runtime feels convenient. The key test is how much custom policy and evidence the team still needs. As those needs grow, it becomes unsafe to thin the repo-owned manual harness too far.
+
 ## Responsibilities
 
 ### Human / Team

--- a/manuscript-en/part-02-context/ch05-context-fundamentals.md
+++ b/manuscript-en/part-02-context/ch05-context-fundamentals.md
@@ -19,6 +19,10 @@ dependencies:
 ## Role in This Book
 Good Prompt Contracts and prompt evals are not enough on their own. An AI agent can still miss the target if it reads the wrong spec, follows stale notes, or gives too much weight to irrelevant logs. CH01 through CH04 established Prompt Engineering as the way to improve single-task reliability. This chapter starts the next layer: Context Engineering.
 
+A common misunderstanding here is that a longer context window makes Context Engineering unnecessary. A wider window increases how much can be transported at once, but the design work remains: decide which material should stay as stable artifacts, which parts should be summarized or compacted, and which information should be reacquired when needed. A larger window increases transport capacity, but it does not replace source-of-truth design, freshness policy, or responsibility split.
+
+As of 2026, runtimes also offer mechanisms such as prompt caching and server-side compaction / context editing that improve context economics. Those mechanisms still do not decide what should be read, what counts as fresh, or what should be synchronized into repo artifacts. In this chapter, they are treated as support for Context Engineering rather than as vendor-feature marketing.
+
 Context Engineering is not about writing a better prompt. It is about deciding what the agent should see, what should be preserved, and what should be discarded. This chapter draws the boundary between Prompt Engineering and Context Engineering, then introduces four context types: persistent, task, session, and tool context. Later chapters build repo context, task context, session memory, skills, and context packs on top of that model.
 
 ## Learning Objectives
@@ -56,6 +60,12 @@ The separation matters because the update speed is different. Architecture docs 
 A context budget is not only about token limits. It is a design policy for what should stay verbatim, what should be summarized, and what should be dropped. `docs/en/context-budget.md` gives that policy explicitly: keep acceptance criteria, interface contracts, verify commands, and destructive-change constraints verbatim; summarize exploratory logs and comparison history; drop stale test output and expired hypotheses.
 
 The reason for that split is practical. Anything that becomes dangerous when paraphrased should stay in its original wording. In `sample-repo/docs/acceptance-criteria/ticket-search.md`, the rule “return all tickets when the query is blank or only whitespace” should remain verbatim. By contrast, the historical reason why ranking became a non-goal can usually be summarized as long as the decision itself remains intact.
+
+Summarize and compact are also different operations. Summarize reduces narrative volume. Compact preserves structure by converting content into tables, bullets, or another easier-to-search form. Re-fetch then makes a different tradeoff: do not keep the material resident; reacquire it when needed. Even with a long context window, it is often safer to rerun live tool output than to keep it permanently in context.
+
+The boundary with modern runtime mechanisms should also be explicit here. Prompt caching avoids resending stable prefixes and repeatedly referenced artifacts in full and mainly improves cost / latency economics. A cache hit does not guarantee correctness or freshness. Cached content is not automatically the source of truth, and external state or verify state still has to be reacquired when needed.
+
+Server-side compaction / context editing serves a different role. When the runtime can summarize older turns or thin lower-priority context on the server side, context pressure drops. But that is only a mechanism that helps `compact` on the runtime side. It does not remove the repo or team policy that decides what must be re-fetched, what must be redacted, and which artifacts must stay synchronized. In other words, prompt caching is support for cheaper keep / persist behavior, while compaction / context editing supports compact behavior. Neither replaces re-fetch, redaction, or artifact sync.
 
 Without a context budget, noisy artifacts pull attention away from the real contract. Long terminal logs and exploratory notes can overshadow current acceptance criteria simply because they are larger or more vivid. In practice, Context Engineering is less about accumulating information and more about declaring information priority.
 
@@ -130,6 +140,7 @@ Comparison points:
 ## Chapter Summary
 - Prompt Engineering defines the work boundary. Context Engineering defines the type, freshness, and priority of the decision material inside that boundary.
 - Context becomes easier to design when it is separated into persistent, task, session, and tool context.
+- Longer context windows, prompt caching, and server-side compaction can improve transport and cost economics, but the design of keep verbatim / summarize / compact / re-fetch / persist still remains.
 - Once those types are visible, the next requirement is a stable repo entry point. The next chapter covers the role split among `AGENTS.md`, `sample-repo/docs/repo-map.md`, and `sample-repo/docs/architecture.md`.
 
 ## Parity Notes

--- a/manuscript-en/part-03-harness/ch09-harness-fundamentals.md
+++ b/manuscript-en/part-03-harness/ch09-harness-fundamentals.md
@@ -23,6 +23,8 @@ Even when repo context, task briefs, and skills are all present, a coding agent 
 
 Harness Engineering starts where Context Engineering stops. Context Engineering designs what the agent should read. Harness Engineering designs how the agent starts, what it may touch, when it may say “done,” and how it should retry or stop. This chapter defines the minimum unit of that system: the single-agent harness. The scope here is not the full verification harness yet. The goal is to establish the minimal execution frame that lets one coding agent finish work safely.
 
+Modern runtimes may provide convenience features such as background execution, hosted tools, and managed context. Those mechanisms can reduce execution friction, but they do not remove repo responsibility for approval boundaries, artifact sync, verify, or review. Making that distinction reader-facing is part of this chapter's job.
+
 ## Learning Objectives
 - Explain the components of a single-agent harness
 - Understand why permission policy and escalation matter
@@ -50,6 +52,20 @@ In this repo, the single-agent harness has six parts:
 | report format | standardizes what must be reported at finish | runbook and done criteria |
 
 `BUG-001` makes the difference clear. If the instruction is only “fix the bug,” the agent can stop after producing a plausible root-cause guess. Once the task runs inside a single-agent harness, startup inputs, permission boundaries, exit states, and verify command are fixed before the first edit begins.
+
+This is also where runtime-managed capability diverges from harness-owned duty. Background execution and hosted tools help with how the work runs, but the repo still has to fix which task brief is the source of truth, where approval begins, and which verify line counts as done. Managed context does not remove artifact sync or report format.
+
+To decide whether a runtime-managed loop is enough or whether a repo-owned manual harness should remain explicit, use the following table. The baseline is fixed: final review / merge remains human-owned, and source-of-truth artifacts remain repo-owned even when the runtime manages execution state.
+
+| Decision factor | When a runtime-managed loop is enough | When a repo-owned manual harness should stay explicit |
+|---|---|---|
+| human approval | there is no extra approval gate beyond final review | human approval is needed before, during, or after execution |
+| evidence / audit trail | runtime status and current-run verify are enough for review | task-specific evidence bundles or audit-oriented records must be preserved |
+| stop / resume logic | the run is linear and closes with simple retry | conditional stop / resume, retry classification, or handoff must be fixed in repo artifacts |
+| source of truth | the task brief, runbook, and done criteria remain fixed during the run | artifact sync, refresh policy, or owned files must stay explicit during the run |
+| review responsibility | the reviewer can read the runtime result as-is | `Changed Files`, `Verification`, and `Remaining Gaps` need explicit packaging for review |
+
+In other words, a runtime-managed loop is a question of whether the mechanism is sufficient, not a question of whether responsibility disappears. Once approval, evidence, stop / resume, or artifact sync become custom, it is unsafe to thin the repo-owned manual harness too far.
 
 CH08 completed the reusable context side. CH09 begins the execution side.
 
@@ -202,6 +218,7 @@ The point of this example is not automation theater. The point is to show that H
 ## Chapter Summary
 - Context Engineering decides what the agent sees. Harness Engineering decides how the agent starts, where it must stop, and what must be true before it may declare completion.
 - The minimum single-agent harness consists of init, work boundary, permission policy, done criteria, verify command, and retry rule.
+- Runtime-managed loops may improve mechanism, but approval boundaries, artifact sync, and review-ready reporting still remain repo-owned duties.
 - Once start and exit conditions are stable, the next missing piece is a verification chain that reviewers can trust. The next chapter focuses on the verification harness itself.
 
 ## Parity Notes

--- a/manuscript-en/part-03-harness/ch10-verification-harness.md
+++ b/manuscript-en/part-03-harness/ch10-verification-harness.md
@@ -60,12 +60,36 @@ The objective is not to create a glossy report. The objective is to preserve eno
 
 `support-hub` is not a UI repo today, so the worked example in this chapter does not require screenshots. But the artifact still matters now, because it fixes the location and format before a UI task arrives. That prevents later ambiguity about where evidence belongs and what must be included.
 
+The important point here is not to use similar words for different kinds of evidence. At minimum, the verification harness should keep three artifacts distinct:
+
+- verify log: the log that keeps the current-run command, timestamp, and result
+- trace: the history that spans sessions or runs, including state changes and handoff
+- evidence bundle: the reviewer-facing bundle that makes the diff inspectable
+
+Freshness is what matters most for a verify log. Yesterday's green log is not today's current-run verify. A trace is different: it is a historical artifact used to understand how the work progressed across a long-running task or a failure analysis. An evidence bundle is reviewer-facing and may include selected verify-log lines, trace references, repro steps, and screenshots. Current-run verify and historical trace therefore serve different purposes, and the bundle is the artifact that prepares them for review.
+
+If trace coverage is going to be used as a metric, a trace cannot stay as a free-form memo. At minimum, any trace cited in review should satisfy a minimum trace reference contract. This does not require a complex tracing system. The seven fields below are enough.
+
+| Field | Role |
+|---|---|
+| task / work-package identifier | identifies which task the trace belongs to |
+| run timestamp or run identifier | connects the trace to the current-run verify |
+| owner / handoff | shows who ran the work and who received it when handoff happened |
+| retry / restart reason | explains why retry or restart was needed |
+| verify reference | shows which current-run verify the trace belongs to |
+| evidence linkage | shows which evidence bundle or review artifact cites the trace |
+| redaction / privacy note | explains the impact when parts were redacted or omitted |
+
+With this contract, a reviewer can identify what the trace refers to. Without a run id or verify reference, a trace may still be a useful historical memo, but it is difficult to count it as trace coverage. Within CH10, trace does not replace current-run verify. It acts as a reference artifact that makes verify easier to explain.
+
 ## 4. Divide Work Between CI and Local Verify
 Local verify and CI verify are not the same thing. Local verify exists for fast iteration before and after each change. CI verify exists to rerun the same acceptance line on the branch and make it shareable across reviewers.
 
 `.github/workflows/verify.yml` makes that division concrete by separating book verification and sample-repo verification into distinct jobs. That matters because the failure modes are different. Manuscript path drift and prompt-eval artifact consistency checks belong to one harness. Sample-repo tests belong to another. Splitting the jobs makes failure classification, retry, and review faster.
 
 The important rule is that CI does not replace local verify. The coding agent should still run `./scripts/verify-book.sh ch10` or `./scripts/verify-sample.sh` locally first. CI then reruns the same standard on the branch. The harness needs both: local speed and shared reproducibility.
+
+This is also where observability connects back into the verification harness. CI job results, verify-log freshness, retry counts recorded in traces, and the existence of an evidence bundle all become inputs for later failure analysis and review-quality diagnosis. Observability is not a separate team's monitoring feature here. It is part of the verification harness.
 
 ## 5. Place Human Approval Explicitly
 A verification harness is not a story about full automation. It also decides where human approval belongs. Approval is needed where verification alone cannot make the final call, or where a human still owns the risk.
@@ -77,9 +101,10 @@ In this chapter, approval is easiest to place in three moments:
    - when CI or verify scripts themselves would change
 2. after verify
    - when the evidence bundle may still be too weak for review
-   - when scope-outside effects may remain
+   - when the verify log may not belong to the current run
+   - when traces or screenshots may still need redaction / privacy treatment
 3. before merge
-   - when the PR summary, verification section, and `Remaining Gaps` must still be checked for clarity
+   - when the PR summary, `Verification`, and `Remaining Gaps` must still be checked for clarity
 
 `checklists/en/verification.md` carries these approval points in practical form. The goal is not to return all decisions to humans. The goal is to mechanize what can be checked and leave only the explicitly human judgments behind.
 
@@ -88,30 +113,30 @@ Bad:
 
 ```text
 The search fix passed `python -m unittest` once.
-CI can be checked later.
-The task probably did not change the UI, so no evidence is needed.
+Yesterday's verify log is still around, so it is probably safe enough.
+Treat trace and evidence as the same thing and dig them up later if needed.
 ```
 
-This turns verification into a memory of one green run. It leaves unclear which tests are the regression guard, whether CI reruns the same bar, and whether evidence is truly unnecessary.
+This blurs the line between current-run verify and historical artifacts. A reviewer cannot tell what belongs to the current run and what belongs to older history.
 
 Corrected:
 
 ```text
 First add or strengthen the regression guard in
 `sample-repo/tests/test_ticket_search.py`.
-Then run `./scripts/verify-sample.sh` locally.
-Let `.github/workflows/verify.yml` rerun the same bar in CI.
-If the change is UI-visible, create an evidence bundle using
-`artifacts/en/evidence/README.md`.
-Use `checklists/en/verification.md` to separate approval-required points.
+Then run `./scripts/verify-sample.sh` locally and keep the current-run verify log.
+If needed, keep retry or handoff history in a trace.
+For review, create an evidence bundle in the format defined by
+`artifacts/en/evidence/README.md` and organize the verify-log and trace references.
+Remove or redact any information that needs privacy treatment before bundling.
 ```
 
-This version treats tests, local verify, CI, evidence, and approval as one harness.
+This keeps tests, current-run verify, historical trace, and reviewer evidence connected as one harness.
 
 Comparison points:
-- The bad version treats verify as a one-off command.
-- The bad version leaves CI and evidence responsibilities vague.
-- The corrected version separates regression guards, shared verify, review evidence, and approval gates.
+- The bad version confuses current-run verify with historical trace.
+- The bad version does not manage evidence freshness or redaction.
+- The corrected version separates verify log, trace, and evidence bundle by role.
 
 ## Worked Example
 Use `FEATURE-001` as the verification-harness example. Its acceptance criteria already include the rule that query matching is case-insensitive. If the tests do not explicitly guard that behavior, a later refactor can break it without immediate notice.

--- a/manuscript-en/part-03-harness/ch12-operating-model.md
+++ b/manuscript-en/part-03-harness/ch12-operating-model.md
@@ -71,7 +71,7 @@ Metrics are not here to answer whether AI agents feel useful. They exist to show
 | throughput | `closed issues / week`, `PR cycle time` | whether work packages are small enough and flow is moving |
 | quality | `verify failure rate`, `post-merge regression count` | whether review and verification are actually catching problems |
 | hygiene | `stale docs count`, `orphaned task brief count`, `missing verification evidence count` | whether entropy cleanup is keeping pace with generation |
-| observability | `queue wait time`, `trace coverage`, `evidence freshness failure` | where the queue is blocked and where explainability is weak |
+| observability | `trace coverage`, `current-run verify availability`, `retry concentration` | where current-run visibility and failure analysis are weak |
 
 The critical rule is to attach action to each metric. If verify failure rate rises, the team should inspect prompt or brief quality. If PR cycle time grows, the team should inspect review budget. If trace coverage falls, the team should suspect a lack of material for failure analysis. If evidence freshness failure rises, the team should suspect that reviewers can no longer confirm current-run verify. If stale docs count and hygiene backlog age worsen, cleanup work should be opened before more feature work. Metrics should support queue diagnosis, failure analysis, and review-quality improvement, not throughput bragging.
 

--- a/manuscript-en/part-03-harness/ch12-operating-model.md
+++ b/manuscript-en/part-03-harness/ch12-operating-model.md
@@ -64,15 +64,18 @@ AI-agent operations accelerate good diffs and bad diffs at the same time. The ac
 Repo hygiene stays a human responsibility for that reason. An agent can detect candidate stale artifacts, but deciding which artifact still holds source-of-truth status often requires human judgment. In this chapter, hygiene does not mean aesthetics. It means keeping the repo safe for the next agent run.
 
 ## 4. Metrics and Retrospectives
-Metrics are not here to answer whether AI agents feel useful. They exist to show whether the operating model is healthy and where it is currently blocked. `docs/en/metrics.md` groups them into three sets:
+Metrics are not here to answer whether AI agents feel useful. They exist to show whether the operating model is healthy and where it is currently blocked. `docs/en/metrics.md` groups them into four sets:
 
 | Group | Example metrics | What they reveal |
 |---|---|---|
 | throughput | `closed issues / week`, `PR cycle time` | whether work packages are small enough and flow is moving |
 | quality | `verify failure rate`, `post-merge regression count` | whether review and verification are actually catching problems |
 | hygiene | `stale docs count`, `orphaned task brief count`, `missing verification evidence count` | whether entropy cleanup is keeping pace with generation |
+| observability | `queue wait time`, `trace coverage`, `evidence freshness failure` | where the queue is blocked and where explainability is weak |
 
-The critical rule is to attach action to each metric. If verify failure rate rises, the team should inspect task decomposition, briefs, or prompt quality. If PR cycle time grows, the team should inspect review budget. If stale docs count rises, the team should inspect hygiene cadence. Metrics should support operating-model adjustment, not blame allocation.
+The critical rule is to attach action to each metric. If verify failure rate rises, the team should inspect prompt or brief quality. If PR cycle time grows, the team should inspect review budget. If trace coverage falls, the team should suspect a lack of material for failure analysis. If evidence freshness failure rises, the team should suspect that reviewers can no longer confirm current-run verify. If stale docs count and hygiene backlog age worsen, cleanup work should be opened before more feature work. Metrics should support queue diagnosis, failure analysis, and review-quality improvement, not throughput bragging.
+
+Trace coverage here does not mean only “a `trace.md` file exists.” For work packages that need traces because they involve long-running work, handoff, retry, or restart, the team should ask whether the minimum trace reference contract is actually present: task / work-package id, run timestamp or run id, owner / handoff, retry / restart reason, verify reference, evidence linkage, and redaction note. That is what keeps historical traces from being confused with current-run verify while still making trace coverage useful for failure analysis.
 
 ## 5. Plan an Adoption Roadmap
 AI-agent adoption is safer when rolled out in stages instead of across the entire repo at once. `docs/en/operating-model.md` already defines three stages:
@@ -125,6 +128,7 @@ Consider a three-person team operating this repo.
   - reviews the PR template output, verification, and evidence
 
 In this setup, one reviewer should hold at most two deep reviews at once. The operator must use `.github/pull_request_template.md` so that `Goal`, `Changed Files`, `Verification`, `Evidence / Approval`, and `Remaining Gaps` are always present. Every week, the team reviews `docs/en/metrics.md`. If `PR cycle time` grows, work packages are reduced further. If stale artifacts grow, `checklists/en/repo-hygiene.md` drives the entropy-cleanup pass.
+If trace coverage drops, the team should recheck long-running-task handoff quality instead of treating the missing history as acceptable noise.
 
 The point of this example is that adoption succeeds or fails based on whether roles and cadence are artifactized. CH12 is therefore an operations chapter, not a model-selection chapter.
 


### PR DESCRIPTION
## Summary
- sync the English chapters and supporting artifacts for the ISSUE #236 scope after PR #237 updated the Japanese source of truth
- add the missing English guidance for prompt caching / server-side compaction, runtime-managed loop vs repo-owned manual harness, and the minimum trace reference contract
- keep the shared Pages generation fix as-is while restoring JP/EN parity on the manuscript and support-artifact side

## Why
PR #237 completed the Japanese-side work for ISSUE #236, but the English counterparts were still behind for the same scope. This follow-up brings the English manuscript and supporting artifacts back in line for the affected context and harness sections.

## Impact
- English CH05 now explains prompt caching and server-side compaction / context editing as context-economics mechanisms without treating them as source-of-truth or freshness replacements
- English CH09 now includes the runtime-managed loop vs repo-owned manual harness decision rule
- English CH10 / CH12 and supporting artifacts now define the minimum trace reference contract and auditable trace coverage rules
- English checklist and evidence guidance now match the updated verification / observability expectations

## Validation
- `./scripts/verify-book.sh`
- `./scripts/verify-sample.sh`
- `./scripts/verify-pages.sh`
- rebuilt Pages output and checked the rendered English sections for CH05 / CH09 / CH10 / CH12

## Notes
- `sample-repo/docs/harness/single-agent-runbook.md` was already a shared English artifact and did not require an additional file-level change in this follow-up
- this PR is a parity follow-up for the ISSUE #236 scope; it does not claim full-book JP/EN parity outside the touched files