### PR TITLE
docs: decide approval boundary strictness

### DIFF
--- a/sample-repo/docs/harness/done-criteria.md
+++ b/sample-repo/docs/harness/done-criteria.md
@@ -6,7 +6,7 @@
 - 変更ファイルが current issue / work package の範囲に収まっている
 - code、docs、tests、task artifact の間に drift がない
 - required artifact が存在し、init 契約を満たしている
-- `./scripts/verify-sample.sh` が current session で通っている
+- `./scripts/verify-sample.sh` が `current session` で通っている
 - `Changed Files`、`Verification`、`Remaining Gaps` を報告できる
 
 ## Chosen Policy Direction
@@ -15,7 +15,7 @@ Issue #227 の方針として、`done` は **approval boundary check + current-r
 簡単な docs 変更であっても、古い verify 結果や推測だけでは `done` にしない。
 
 - `current session` の foreground command 実行は許可されるが、実行した command と結果を `Verification` に残す。
-- destructive git command、background process、repo-external write、parallel agent、secret / credential 操作を実行していないことを確認する。
+- destructive git command、永続的な background process、repo 外への書き込み、追加 agent の spawn、parallel writer の起動、secret / credential 操作を実行していないことを確認する。
 - missing required artifact、approval pending、または未解決の verify failure がある場合は `done` ではなく `blocked` または `needs-human-approval` にする。
 - Evidence Minimum は緩和せず、少なくとも verify command、実行結果、未実行 check の理由を報告できる状態にする。
 
@@ -29,7 +29,7 @@ Issue #227 の方針として、`done` は **approval boundary check + current-r
 
 - 実行した verify command をそのまま言える
 - pass / fail と、未実行の check があればその理由を言える
-- verify が古い実行結果ではなく current run に紐づいている
+- verify が古い実行結果ではなく `current run` に紐づいている
 - required artifact の有無を current tree で確認している
 
 ## Bugfix Addendum

--- a/sample-repo/docs/harness/done-criteria.md
+++ b/sample-repo/docs/harness/done-criteria.md
@@ -1,31 +1,50 @@
 # Done Criteria
 
 ## Core
+
 - task brief の Goal と Acceptance Criteria を満たす
 - 変更ファイルが current issue / work package の範囲に収まっている
 - code、docs、tests、task artifact の間に drift がない
+- required artifact が存在し、init 契約を満たしている
 - `./scripts/verify-sample.sh` が current session で通っている
 - `Changed Files`、`Verification`、`Remaining Gaps` を報告できる
 
+## Chosen Policy Direction
+
+Issue #227 の方針として、`done` は **approval boundary check + current-run evidence** を必須条件にする。
+簡単な docs 変更であっても、古い verify 結果や推測だけでは `done` にしない。
+
+- `current session` の foreground command 実行は許可されるが、実行した command と結果を `Verification` に残す。
+- destructive git command、background process、repo-external write、parallel agent、secret / credential 操作を実行していないことを確認する。
+- missing required artifact、approval pending、または未解決の verify failure がある場合は `done` ではなく `blocked` または `needs-human-approval` にする。
+- Evidence Minimum は緩和せず、少なくとも verify command、実行結果、未実行 check の理由を報告できる状態にする。
+
 ## Approval Boundary Check
+
 - approval が必要な変更を、承認なしで実行していない
 - approval 待ちの項目がある場合、exit state を `done` にしない
+- `permission-policy.md` の `Agent May Proceed` と `Require Human Approval` のどちらに該当したかを説明できる
 
 ## Evidence Minimum
+
 - 実行した verify command をそのまま言える
 - pass / fail と、未実行の check があればその理由を言える
 - verify が古い実行結果ではなく current run に紐づいている
+- required artifact の有無を current tree で確認している
 
 ## Bugfix Addendum
+
 - failing behavior を test で再現した、または既存 test で回帰 guard を確認した
 - Root Cause を 1 段落で説明できる
 - 不要な public interface 変更を入れていない
 
 ## Feature Or Docs Addendum
+
 - spec、acceptance criteria、design doc の差分が現行挙動と一致している
 - non-goals を scope に混ぜていない
 
 ## Exit States
+
 - `done`: Core、Approval Boundary Check、Evidence Minimum と task 種別の追加条件を満たす
-- `blocked`: 入力不足、矛盾する artifact、未解決の verify failure がある
+- `blocked`: 入力不足、矛盾する artifact、missing required artifact、未解決の verify failure がある
 - `needs-human-approval`: permission policy の approval 条件に入った

--- a/sample-repo/docs/harness/permission-policy.md
+++ b/sample-repo/docs/harness/permission-policy.md
@@ -1,17 +1,32 @@
 # Permission Policy
 
 ## Purpose
+
 single-agent harness で、coding agent が自律で進めてよい変更と human approval が必要な変更を分ける。
 
+## Chosen Policy Direction
+
+Issue #227 の方針として、permission policy は **strict-by-default** を維持する。
+Runtime が foreground command、hosted tool、または自動実行を提供していても、承認境界はこの artifact を source of truth とする。
+
+- current session で完結する foreground command は、task brief の範囲内で、短時間に終了し、repo 内の検証・調査・生成に閉じる場合だけ自律実行してよい。
+- destructive な git command、永続的な background process、repo 外への書き込み、secret / credential を使う操作、追加 agent の spawn、parallel writer の起動は human approval のまま維持する。
+- `done` 判定では、approval boundary を越えていないことを明示的に確認する。
+- required artifact が欠けている場合は、推測で補完せず `Stop And Report` として扱う。
+
 ## Agent May Proceed
+
 - task brief に含まれる範囲での code / docs / tests 更新
 - failing test の追加または更新
 - 変更した挙動に追随する docs / task artifact の同期
 - read-only の調査コマンド、`./scripts/verify-sample.sh` の実行
 - scope 内の `Progress Note` 更新
 - current session で完結する foreground command の実行
+  - 例: repo 内の test、lint、format、build、grep、生成スクリプト
+  - 条件: command が foreground で終了し、永続 process を残さず、repo 外へ書き込まず、secret / credential を要求しない
 
 ## Require Human Approval
+
 - public interface、CLI、出力契約の変更
 - `docs/domain-overview.md`、`docs/architecture.md` にあるドメイン前提の変更
 - verify script、CI、permission policy 自体の変更
@@ -22,12 +37,15 @@ single-agent harness で、coding agent が自律で進めてよい変更と hum
 - stated work package の外側へ広がる変更
 
 ## Stop And Report
+
 - task brief、spec、tests の間で矛盾があり source of truth が決められない
 - 現在の diff と無関係な verify failure が出ている
 - 他者の未理解な差分や unexpected dirty file があり、上書きの危険がある
 - required artifact が欠けていて init 契約を満たせない
+- approval が必要な操作をしないと acceptance criteria を満たせない
 
 ## Escalation Format
+
 - Requested Change
 - Reason Approval Is Needed
 - Affected Files

--- a/sample-repo/docs/harness/permission-policy.md
+++ b/sample-repo/docs/harness/permission-policy.md
@@ -9,7 +9,7 @@ single-agent harness で、coding agent が自律で進めてよい変更と hum
 Issue #227 の方針として、permission policy は **strict-by-default** を維持する。
 Runtime が foreground command、hosted tool、または自動実行を提供していても、承認境界はこの artifact を source of truth とする。
 
-- current session で完結する foreground command は、task brief の範囲内で、短時間に終了し、repo 内の検証・調査・生成に閉じる場合だけ自律実行してよい。
+- `current session` で完結する foreground command は、task brief の範囲内で、短時間に終了し、repo 内の検証・調査・生成に閉じる場合だけ自律実行してよい。
 - destructive な git command、永続的な background process、repo 外への書き込み、secret / credential を使う操作、追加 agent の spawn、parallel writer の起動は human approval のまま維持する。
 - `done` 判定では、approval boundary を越えていないことを明示的に確認する。
 - required artifact が欠けている場合は、推測で補完せず `Stop And Report` として扱う。
@@ -21,7 +21,7 @@ Runtime が foreground command、hosted tool、または自動実行を提供し
 - 変更した挙動に追随する docs / task artifact の同期
 - read-only の調査コマンド、`./scripts/verify-sample.sh` の実行
 - scope 内の `Progress Note` 更新
-- current session で完結する foreground command の実行
+- `current session` で完結する foreground command の実行
   - 例: repo 内の test、lint、format、build、grep、生成スクリプト
   - 条件: command が foreground で終了し、永続 process を残さず、repo 外へ書き込まず、secret / credential を要求しない
 


### PR DESCRIPTION
## Summary
- Document the Issue #227 policy decision as strict-by-default for sample-repo harness approvals.
- Clarify that current-session foreground commands are allowed only when bounded to the task, repo-local, non-persistent, and credential-free.
- Keep destructive git commands, persistent background processes, repo-external writes, secret/credential operations, spawned agents, and parallel writers behind human approval.
- Strengthen done criteria so approval-boundary checks, required-artifact checks, and current-run verification evidence remain mandatory.

Closes #227

## Validation
- `git diff --check`
- `./scripts/verify-sample.sh`
- `./scripts/verify-book.sh`
- `TMPDIR=/home/devuser/work/CodeX/booksB/.codex-local/tmp ./scripts/verify-pages.sh`
- `npx --yes markdownlint-cli --disable MD013 MD034 -- sample-repo/docs/harness/permission-policy.md sample-repo/docs/harness/done-criteria.md`