### PR TITLE
docs: decide source guidance specificity

### DIFF
--- a/manuscript-en/backmatter/00-source-notes.md
+++ b/manuscript-en/backmatter/00-source-notes.md
@@ -19,6 +19,12 @@ Keep the trust order fixed.
 
 If that order drifts, the manuscript becomes too dependent on fashion, screenshots, or one-off success stories. This is especially important around AI agents, where behavior and product surfaces change quickly. Prefer the official behavior of the tool you are actually using over generalized commentary.
 
+## Source Specificity
+
+By default, this book keeps source guidance at the tool-category level: coding-agent runtime, VCS, CI, issue tracker, test framework, orchestration tool, and organizational policy. Name a specific vendor or product document only when the chapter depends on current API, CLI, permission, pricing, or protocol behavior. When that happens, record the confirmation date and `model/runtime profile` with the evidence rather than treating the product name as a stable backmatter anchor.
+
+For CH07, CH11, and CH12, backmatter should explicitly name the operating-model terms that define artifacts or responsibilities: `restart packet (Resume Packet)`, `Progress Note`, `approval boundary`, and Lead / Operator / Reviewer. Source notes and figure plans should still remain neutral navigation aids, not sentence-level mirrors of chapter prose.
+
 ## Chapter-by-Chapter Source Notes
 
 ### CH01 Where AI Agents Fail
@@ -73,8 +79,8 @@ If that order drifts, the manuscript becomes too dependent on fashion, screensho
 
 ### CH11 Long-running Tasks and Multi-agent Work
 
-- Start with `sample-repo/docs/harness/feature-list.md`, `sample-repo/docs/harness/restart-protocol.md`, `sample-repo/docs/harness/multi-agent-playbook.md`, and `sample-repo/tasks/FEATURE-002-plan.md`. Multi-agent work becomes safe only after the role split and `restart packet` are concrete.
-- If you add external sources, prefer official docs for the orchestration tool or task queue you use. Do not separate the parallelization discussion from write scope and handoff artifacts.
+- Start with `sample-repo/docs/harness/feature-list.md`, `sample-repo/docs/harness/restart-protocol.md`, `sample-repo/docs/harness/multi-agent-playbook.md`, and `sample-repo/tasks/FEATURE-002-plan.md`. Multi-agent work becomes safe only after the planner / coder / reviewer / verifier split, `restart packet`, and `approval boundary` are concrete.
+- If you add external sources, prefer official docs for the orchestration tool or task queue you use. Do not separate the parallelization discussion from write scope, handoff artifacts, and pending approval items.
 
 ### CH12 Operating Model and Organizational Adoption
 

--- a/manuscript-en/backmatter/01-reading-guide.md
+++ b/manuscript-en/backmatter/01-reading-guide.md
@@ -19,6 +19,8 @@ In the 2026 edition, use sources in the following order.
 
 If the prose and the live tool differ, keep the design principle from the manuscript and re-read the execution conditions in the primary source.
 
+Keep the naming rule explicit. This guide normally points to categories such as the agent runtime in use, the VCS / CI system in use, and internal policy. Name a specific vendor or product document only when you must confirm API, CLI, permission, pricing, or protocol behavior, and track the confirmation date plus `model/runtime profile` with the evidence.
+
 ## Prompts and Requirements Shaping
 
 | Source | What It Strengthens | Related Chapters |
@@ -35,7 +37,7 @@ If the prose and the live tool differ, keep the design principle from the manusc
 | Official docs for the agent runtime in use | Instruction layering, workspace access, and session handling | CH05, CH06, CH07, CH08 |
 | Official docs for the VCS, CI, and package manager in use | Issues, pull requests, review flow, branch protection, and artifact traceability | CH03, CH06, CH10 |
 | Internal repo maps, architecture docs, and coding standards | Canonical repo context and clearer ownership | CH06 |
-| Internal handoff, incident, and change-log rules | Session memory, `restart packet`, handoff contracts, and approval boundaries | CH07, CH11 |
+| Internal handoff, incident, and change-log rules | Session memory, `restart packet (Resume Packet)`, `Progress Note`, handoff contracts, and `approval boundary` | CH07, CH11, CH12 |
 
 ## Verification, Reliability, and Operations
 
@@ -46,7 +48,7 @@ If the prose and the live tool differ, keep the design principle from the manusc
 | Betsy Beyer et al., *The Site Reliability Workbook* | Checklists, runbooks, and implementation-focused operations design | CH09, CH10, CH11, CH12 |
 | Nicole Forsgren, Jez Humble, Gene Kim, *Accelerate* | Metrics, throughput, and operational improvement | CH10, CH12 |
 | Internal approval and permission policy | Human approval gates, authority boundaries, and auditability | CH09, CH12 |
-| Internal PR templates, review checklists, and merge policy | `Goal`, `Changed Files`, `Scope and Non-goals`, `Verification`, `Evidence / Approval`, and review-budget operations | CH10, CH12 |
+| Internal PR templates, review checklists, and merge policy | Lead / Operator / Reviewer responsibilities, `Goal`, `Changed Files`, `Scope and Non-goals`, `Verification`, `Evidence / Approval`, and review-budget operations | CH10, CH12 |
 
 ## How to Choose Which Source to Read Next
 

--- a/manuscript-en/backmatter/03-figure-table-list-policy.md
+++ b/manuscript-en/backmatter/03-figure-table-list-policy.md
@@ -13,7 +13,8 @@ This file is the source of truth for building the figure list and table list in 
 - Treat `manuscript-en/figures/figure-plan.md` as the source of truth for figure ID, chapter, caption, and first mention
 - Keep each caption reader-facing so the main lesson of the figure is visible in one line
 - Preserve the rule of one figure for one main message, then swap only the production numbering later
-- Keep captions and first mentions aligned with glossary and chapter wording so `restart packet`, `Progress Note`, and `approval boundary` do not drift
+- Keep captions and first mentions aligned with glossary and chapter wording so `restart packet`, `Progress Note`, `approval boundary`, and Lead / Operator / Reviewer do not drift
+- Do not make vendor or product names the source of truth for the figure list. Align only canonical terms with chapter prose and keep explanatory wording neutral for re-reference
 
 ## Current Figure Seed
 
@@ -25,7 +26,7 @@ This file is the source of truth for building the figure list and table list in 
 | `fig-04` | CH09 | The overall single-agent harness flow | `manuscript-en/figures/fig-04-single-agent-harness.mmd` |
 | `fig-05` | CH10 | The order of lint, typecheck, unit, and e2e | `manuscript-en/figures/fig-05-verification-pipeline.mmd` |
 | `fig-06` | CH11 | The split among planner / coder / reviewer / verifier | `manuscript-en/figures/fig-06-long-running-multi-agent.mmd` |
-| `fig-07` | CH12 | The responsibilities that remain with humans | `manuscript-en/figures/fig-07-operating-model.mmd` |
+| `fig-07` | CH12 | The responsibilities that remain with Lead / Operator / Reviewer | `manuscript-en/figures/fig-07-operating-model.mmd` |
 
 ## Table List Policy
 

--- a/manuscript-en/figures/fig-07-operating-model.mmd
+++ b/manuscript-en/figures/fig-07-operating-model.mmd
@@ -1,8 +1,8 @@
 %% title: fig-07 operating model
 %% chapter: CH12
-%% caption: An operating model stays stable by cycling through human and agent responsibilities, review budget, metrics, and cleanup cadence.
+%% caption: An operating model stays stable by cycling through Lead / Operator / Reviewer and agent responsibilities, `approval boundary`, review budget, metrics, and cleanup cadence.
 flowchart LR
-    H[Human<br/>priority / approval / final review] --> A[Agent<br/>explore / edit / verify / report]
+    H[Lead / Operator / Reviewer<br/>priority / approval / final review] --> A[Agent<br/>explore / edit / verify / report]
     A --> R[Review Budget]
     R --> M[Metrics]
     M --> C[Cleanup Cadence]

--- a/manuscript-en/figures/figure-plan.md
+++ b/manuscript-en/figures/figure-plan.md
@@ -2,6 +2,10 @@
 
 This plan fixes the book's main ideas as reader-facing figures for the English edition. Production figure numbers will be decided later, but this file remains the source of truth for source files and chapter progression.
 
+## Editorial Wording Policy
+
+Figure captions should preserve canonical terms from the glossary and chapter prose. Terms such as `restart packet`, `approval boundary`, and Lead / Operator / Reviewer must not drift inside figures. At the same time, captions should be neutral re-reference text rather than sentence-level copies of chapter prose. Vendor and product names are not the source of truth for the figure plan.
+
 | Figure ID | Chapter | Suggested Placement | Caption | Reader Value | Source |
 |---|---|---|---|---|---|
 | `fig-01` | CH01 | Right after the map from Prompt Engineering to Context Engineering to Harness Engineering | Prompt / Context / Harness stack in the order that reduces wrong answers, forgetting, and breaking things or stopping early. | Even a quick browse should make the book's promise and progression visible in one page. | `fig-01-maturity-model.mmd` |
@@ -10,4 +14,4 @@ This plan fixes the book's main ideas as reader-facing figures for the English e
 | `fig-04` | CH09 | Right after the section that explains the single-agent harness as a whole | A single-agent harness combines init, boundary, permission, verify, exit, and report inside one execution frame. | Makes it clear that Harness Engineering is not prompt wording but the design of start and stop conditions. | `fig-04-single-agent-harness.mmd` |
 | `fig-05` | CH10 | Right after the section on lint, typecheck, unit, and e2e order | A verification harness connects failing test, local verify, CI, evidence, and approval in a fixed sequence. | Helps the reader see verification as a review-ready pipeline rather than a single command. | `fig-05-verification-pipeline.mmd` |
 | `fig-06` | CH11 | Right after the section that separates planner / coder / reviewer / verifier | A long-running task becomes safe to split into multi-agent work only after the feature list, `restart packet`, `approval boundary`, and role split are in place. | Makes the relationship between long-running work and multi-agent delegation easy to re-find later as a responsibility map. | `fig-06-long-running-multi-agent.mmd` |
-| `fig-07` | CH12 | Right after the section on the responsibilities that remain with humans | An operating model stays stable by cycling through human and agent responsibilities, review budget, metrics, and cleanup cadence. | Helps teams read adoption as a design problem of responsibility and cadence, not only of model choice. | `fig-07-operating-model.mmd` |
+| `fig-07` | CH12 | Right after the section on the responsibilities that remain with Lead / Operator / Reviewer | An operating model stays stable by cycling through Lead / Operator / Reviewer and agent responsibilities, `approval boundary`, review budget, metrics, and cleanup cadence. | Helps teams read adoption as a design problem of responsibility, approval boundaries, and cadence, not only of model choice. | `fig-07-operating-model.mmd` |

--- a/manuscript/backmatter/00-source-notes.md
+++ b/manuscript/backmatter/00-source-notes.md
@@ -19,6 +19,12 @@
 
 この順番を崩すと、本文の主張が流行語や一発成功例に引きずられやすい。特に AI agent 周辺は情報の更新が速いため、一般論より「いま自分が使っている tool の official behavior」を優先する。
 
+## Source Specificity
+
+本書の source guidance は、原則として tool category level で書く。coding agent runtime、VCS、CI、issue tracker、test framework、orchestration tool、組織ポリシーのように、読者が自分の環境へ対応づけられる粒度を正本にする。特定 vendor / product の document 名は、章本文が現在の API、CLI、permission、pricing、protocol behavior に依存するときだけ例示し、その場合は確認日と `model/runtime profile` を evidence 側へ残す。
+
+CH07、CH11、CH12 の後付けでは、`restart packet（Resume Packet）`、`Progress Note`、`approval boundary`、Lead / Operator / Reviewer のような operating-model term を明示する。ただし、source notes と figure plan は章本文の言い換えではなく、読者が再参照するための中立的な案内に留める。
+
 ## 章別 Source Notes
 
 ### CH01 AIエージェントはどこで失敗するか
@@ -73,8 +79,8 @@
 
 ### CH11 Long-running Task と Multi-agent
 
-- 最初に信頼するのは `sample-repo/docs/harness/feature-list.md`、`sample-repo/docs/harness/restart-protocol.md`、`sample-repo/docs/harness/multi-agent-playbook.md`、`sample-repo/tasks/FEATURE-002-plan.md` である。multi-agent は role split と `restart packet` が揃って初めて扱う。
-- 外部 source を足すなら、使っている orchestration tool や task queue の公式 docs を優先する。並列化の議論を、write scope と handoff artifact から切り離さない。
+- 最初に信頼するのは `sample-repo/docs/harness/feature-list.md`、`sample-repo/docs/harness/restart-protocol.md`、`sample-repo/docs/harness/multi-agent-playbook.md`、`sample-repo/tasks/FEATURE-002-plan.md` である。multi-agent は planner / coder / reviewer / verifier の role split、`restart packet`、`approval boundary` が揃って初めて扱う。
+- 外部 source を足すなら、使っている orchestration tool や task queue の公式 docs を優先する。並列化の議論を、write scope、handoff artifact、approval 待ち項目から切り離さない。
 
 ### CH12 運用モデルと組織導入
 

--- a/manuscript/backmatter/01-読書案内.md
+++ b/manuscript/backmatter/01-読書案内.md
@@ -19,6 +19,8 @@
 
 本文と tool 挙動が食い違うときは、設計原則は本文で保持し、実行条件は一次情報で読み替える。
 
+具体名を足す条件も固定する。読書案内では、通常は `利用中 agent runtime`、`利用中 VCS / CI`、`組織内 policy` のような category 名で案内する。特定 vendor / product の document 名を挙げるのは、API、CLI、permission、pricing、protocol behavior の確認が必要な場合に限り、確認日と `model/runtime profile` を evidence 側で追跡する。
+
 ## Prompt と要求定義
 
 | source | 何を補強するか | 関連章 |
@@ -35,7 +37,7 @@
 | 利用中 agent runtime の official docs | instruction layering、workspace access、session の持ち方 | CH05, CH06, CH07, CH08 |
 | 利用中 VCS / CI / package manager の official docs | issue、PR、review、branch protection、artifact 追跡 | CH03, CH06, CH10 |
 | 組織内の repo-map、architecture、coding standards | repo context の正本化、ownership の明確化 | CH06 |
-| handoff / incident / change log の組織ルール | session memory、`restart packet`、handoff contract、approval boundary | CH07, CH11 |
+| handoff / incident / change log の組織ルール | session memory、`restart packet（Resume Packet）`、`Progress Note`、handoff contract、`approval boundary` | CH07, CH11, CH12 |
 
 ## 検証・信頼性・運用
 
@@ -46,7 +48,7 @@
 | Betsy Beyer ほか, *The Site Reliability Workbook* | checklist、runbook、運用設計の実装寄りの進め方 | CH09, CH10, CH11, CH12 |
 | Nicole Forsgren, Jez Humble, Gene Kim, *Accelerate* | metrics、throughput、運用改善の見方 | CH10, CH12 |
 | 組織内の approval / permission policy | human approval gate、越権防止、監査性 | CH09, CH12 |
-| 組織内の PR template / review checklist / merge policy | `Goal`、`Changed Files`、`Scope and Non-goals`、`Verification`、`Evidence / Approval`、review budget の運用 | CH10, CH12 |
+| 組織内の PR template / review checklist / merge policy | Lead / Operator / Reviewer の責務、`Goal`、`Changed Files`、`Scope and Non-goals`、`Verification`、`Evidence / Approval`、review budget の運用 | CH10, CH12 |
 
 ## 使い分けの原則
 

--- a/manuscript/backmatter/03-図表一覧方針.md
+++ b/manuscript/backmatter/03-図表一覧方針.md
@@ -13,7 +13,8 @@
 - 図 ID、対象章、caption、first mention は `manuscript/figures/figure-plan.md` を正本にする
 - 図一覧では「図から何を理解してほしいか」が 1 行で分かる caption を維持する
 - 1 図 = 1 主メッセージを守り、組版後に図番号だけを差し替える
-- caption と first mention は glossary / chapter wording に合わせ、`restart packet`、`Progress Note`、`approval boundary` の表記 drift を残さない
+- caption と first mention は glossary / chapter wording に合わせ、`restart packet`、`Progress Note`、`approval boundary`、Lead / Operator / Reviewer の表記 drift を残さない
+- vendor / product 名は図一覧の正本にしない。図表一覧では canonical term だけを章本文と揃え、説明文は再参照用に中立的に保つ
 
 ## 現時点の図 seed
 
@@ -25,7 +26,7 @@
 | `fig-04` | CH09 | single-agent harness の全体像 | `manuscript/figures/fig-04-single-agent-harness.mmd` |
 | `fig-05` | CH10 | lint / typecheck / unit / e2e の順序 | `manuscript/figures/fig-05-verification-pipeline.mmd` |
 | `fig-06` | CH11 | planner / coder / reviewer / verifier の分離 | `manuscript/figures/fig-06-long-running-multi-agent.mmd` |
-| `fig-07` | CH12 | 人間が残す責務 | `manuscript/figures/fig-07-operating-model.mmd` |
+| `fig-07` | CH12 | Lead / Operator / Reviewer が残す責務 | `manuscript/figures/fig-07-operating-model.mmd` |
 
 ## 表一覧の方針
 

--- a/manuscript/figures/fig-07-operating-model.mmd
+++ b/manuscript/figures/fig-07-operating-model.mmd
@@ -1,8 +1,8 @@
 %% title: fig-07 operating model
 %% chapter: CH12
-%% caption: operating model は Human と Agent の責務、review budget、metrics、cleanup cadence を循環させて保つ。
+%% caption: operating model は Lead / Operator / Reviewer と Agent の責務、`approval boundary`、review budget、metrics、cleanup cadence を循環させて保つ。
 flowchart LR
-    H[Human<br/>priority / approval / final review] --> A[Agent<br/>explore / edit / verify / report]
+    H[Lead / Operator / Reviewer<br/>priority / approval / final review] --> A[Agent<br/>explore / edit / verify / report]
     A --> R[Review Budget]
     R --> M[Metrics]
     M --> C[Cleanup Cadence]

--- a/manuscript/figures/figure-plan.md
+++ b/manuscript/figures/figure-plan.md
@@ -2,6 +2,10 @@
 
 本書の主要概念を reader-facing な図版として固定するための plan。図番号そのものは組版工程で確定するが、ここでは source file と chapter progression を正本として管理する。
 
+## Editorial Wording Policy
+
+図の caption は、glossary と章本文にある canonical term をそのまま使う。`restart packet`、`approval boundary`、Lead / Operator / Reviewer のような term は図内で drift させない。一方で、caption は章本文の文をそのまま写すのではなく、再参照しやすい中立的な説明にする。vendor / product 名は図 plan の正本にしない。
+
 | 図 ID | 対象章 | 挿入候補 | Caption | 読者価値 | Source |
 |---|---|---|---|---|---|
 | `fig-01` | CH01 | 「Prompt Engineering / Context Engineering / Harness Engineering の対応表」の直後 | Prompt / Context / Harness は、誤答・忘却・破壊/停止という failure mode を減らす順に積み上がる。 | 書店での立ち読みでも本書の promise と progression が 1 枚で伝わる。 | `fig-01-maturity-model.mmd` |
@@ -10,4 +14,4 @@
 | `fig-04` | CH09 | 「single-agent harness の全体像」の直後 | single-agent harness は init、boundary、permission、verify、exit、report を 1 つの実行枠にまとめる。 | Harness Engineering が prompt の言い換えではなく、開始条件と終了条件の設計だと分かる。 | `fig-04-single-agent-harness.mmd` |
 | `fig-05` | CH10 | 「lint / typecheck / unit / e2e の順序」の直後 | verification harness は failing test、local verify、CI、evidence、approval を順序付きでつなぐ。 | verify を単発コマンドではなく review-ready に向かう pipeline として読める。 | `fig-05-verification-pipeline.mmd` |
 | `fig-06` | CH11 | 「planner / coder / reviewer / verifier の分離」の直後 | long-running task は feature list、`restart packet`、`approval boundary`、role 分担が揃って初めて安全に multi-agent へ分割できる。 | long-running task と multi-agent の関係を責務図として再参照できる。 | `fig-06-long-running-multi-agent.mmd` |
-| `fig-07` | CH12 | 「人間が残す責務」の直後 | operating model は Human と Agent の責務、review budget、metrics、cleanup cadence を循環させて保つ。 | チーム導入を「モデル選定」ではなく「責務と cadence の設計」として理解しやすくする。 | `fig-07-operating-model.mmd` |
+| `fig-07` | CH12 | 「Lead / Operator / Reviewer が残す責務」の直後 | operating model は Lead / Operator / Reviewer と Agent の責務、`approval boundary`、review budget、metrics、cleanup cadence を循環させて保つ。 | チーム導入を「モデル選定」ではなく「責務、承認境界、cadence の設計」として理解しやすくする。 | `fig-07-operating-model.mmd` |


### PR DESCRIPTION
## Summary
- Decide that source guidance stays at tool-category level by default, with vendor/product documents named only when current API/CLI/permission/pricing/protocol behavior must be confirmed.
- Add the same specificity rule to JP/EN source notes and reading guide.
- Keep CH07/CH11/CH12 support prose explicit about `restart packet (Resume Packet)`, `Progress Note`, `approval boundary`, and relevant role names while keeping source notes and figure plans editorially neutral.
- Align JP/EN figure-list policy, figure plans, and `fig-07` Mermaid metadata so canonical terms do not drift.

Closes #229

## Verification
- `git diff --check`
- `./scripts/verify-book.sh`
- `TMPDIR=/home/devuser/work/CodeX/booksB/.codex-local/tmp ./scripts/verify-pages.sh`
- `npx --yes markdownlint-cli --disable MD012 MD013 MD022 MD025 MD032 MD034 MD060 -- manuscript/backmatter/00-source-notes.md manuscript/backmatter/01-読書案内.md manuscript/backmatter/03-図表一覧方針.md manuscript/figures/figure-plan.md manuscript-en/backmatter/00-source-notes.md manuscript-en/backmatter/01-reading-guide.md manuscript-en/backmatter/03-figure-table-list-policy.md manuscript-en/figures/figure-plan.md`
- `python3 scripts/build-pages.py --output /home/devuser/work/CodeX/booksB/.codex-local/tmp/ai-agent-issue229-site`
- Targeted built-site marker smoke for JP/EN backmatter 00/01/03 pages
- GitHub Actions on head `0b80493`: `verify-book`, `verify-pages`, and `verify-sample` passed

## Review follow-up
- Copilot generated 3 inline comments; all were fixed, replied to, and resolved.
- Codex automated review generated 1 inline comment; it was fixed, replied to, and resolved.
- `pr-review-completeness`: `status: ok`, unresolved threads `0`.
