### PR TITLE
[codex] Keep Pages verify temp files local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 _site/
 *.egg-info/
 artifacts/evidence/generated/
+.tmp/

--- a/scripts/verify-pages.sh
+++ b/scripts/verify-pages.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TMPDIR="$(mktemp -d)"
+TMP_ROOT="$ROOT/.tmp"
+mkdir -p "$TMP_ROOT"
+TMPDIR="$(mktemp -d "$TMP_ROOT/verify-pages.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 python3 -m venv "$TMPDIR/.venv"


### PR DESCRIPTION
## Summary
- update `scripts/verify-pages.sh` to create its temporary virtualenv and built-site smoke output under repo-local `.tmp/` instead of the system temp directory
- add `.tmp/` to `.gitignore` so local verification artifacts remain untracked

## Why
- the Pages verifier already removes its per-run directory on exit, but using a repo-local temp root keeps managed verification artifacts inside the working tree subtree and makes the temporary output location explicit
- this reduces accidental out-of-tree scratch usage during local quality-sprint verification without changing the generated Pages artifacts or CI behavior

## Validation
- `./scripts/verify-book.sh`
- `./scripts/verify-sample.sh`
- `./scripts/verify-pages.sh` (output path observed under `.tmp/verify-pages.*/site`)
- `git diff --check`