### PR TITLE
日英チェックリストとトラブルシューティングを公開

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -1,0 +1,52 @@
+# Safety-First Troubleshooting Flow
+
+When an AI-agent task does not behave as expected, prioritize containing impact and preserving decision evidence over fixing it quickly. This reader-facing flow isolates Prompt, Context, and Harness failure modes with the smallest safe action.
+
+## 0. Stop Immediately and Protect the Boundary
+
+Do not retry or take additional action when any of the following applies:
+
+- production, customer data, credentials, public exposure, billing, or destructive commands may be affected
+- the Permission Policy, Tool Contract, or Approval Gate boundary is unclear
+- the failure has produced unexpected file changes, external submission, privilege escalation, or missing data
+
+Stopping is not failure. It preserves the safety boundary so that the next owner can make an informed decision.
+
+## 1. Record the Symptoms
+
+First, record the expected behavior separately from the actual Symptoms. Preserve the task, run timestamp or run ID, inputs, executed command, error, changed files, and whether an external operation occurred. Do not treat an old log or trace as a substitute for current-run verification.
+
+## 2. Reproduce with the Smallest Input
+
+Reproduce the same Symptoms with a read-only or isolated minimum input. If the failure does not Reproduce, state which input, environment, permission, or timing condition differs from the original run. Do not use production data or an unapproved external operation to reproduce it.
+
+## 3. Perform a Minimum Safe Check
+
+Before making a change, confirm the target repository, branch, working tree, allowed tools and commands, network access, and approval requirement. If a safe check cannot establish the scope, Stop rather than expanding the hypothesis.
+
+## 4. Diagnose the Prompt
+
+Check whether the Objective, Inputs, Constraints, Tool Contract, Completion Criteria, and Refusal / Stop Conditions are present as observable conditions. Ambiguous requests, conflicting constraints, and a missing output contract are Prompt failure modes. When changing a Prompt, define the expected output first with the minimum reproduction input.
+
+## 5. Diagnose the Context
+
+Check whether the required artifacts, target files, terminology, existing decisions, and current state are in Context. Stale information, irrelevant bulk input, swapped JA/EN counterparts, and absolute paths are Context failure modes. Identify one source of truth at a time before adding more Context.
+
+## 6. Diagnose the Harness
+
+Check execution order, tool permissions, timeouts, retries, the verification command, divergence from CI, and evidence preservation. Even with a correct Prompt and Context, do not call work safely complete when the Harness boundary or verification is missing. Isolate a Harness failure through commands and outcomes, not retry count.
+
+## 7. Decide When to Stop and Escalate
+
+Stop and Escalate to the appropriate owner or approver when:
+
+- a decision would cross a safety boundary, Permission Policy, or Approval Gate
+- the minimum reproduction still leaves possible data loss, security, privacy, or external impact
+- no single Prompt, Context, or Harness failure mode explains the result and sources of truth conflict
+- current-run verification cannot run or its failure mode cannot be explained
+
+Include the Symptoms, reproduction conditions, reason for stopping, minimum safe checks attempted, and decision needed in the escalation.
+
+## 8. Preserve Evidence
+
+Under Evidence / Approval, preserve the executed command, run timestamp or run ID, pass or fail result, relevant diff, trace, redaction requirement, approver, and decision inputs. Evidence prevents the next retry, review, or handoff from repeating the same risky operation.

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -10,7 +10,7 @@ Do not retry or take additional action when any of the following applies:
 - the Permission Policy, Tool Contract, or Approval Gate boundary is unclear
 - the failure has produced unexpected file changes, external submission, privilege escalation, or missing data
 
-Stopping is not failure. It preserves the safety boundary so that the next owner can make an informed decision.
+Stopping is not a failure. It preserves the safety boundary so that the next owner can make an informed decision.
 
 ## 1. Record the Symptoms
 

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -7,7 +7,7 @@
 ## 構成
 
 - `scripts/build-pages.py`
-  - 日本語版と英語版の原稿から book-formatter 互換の static HTML を生成する
+  - 日本語版と英語版の原稿、および reader resource の source mapping から book-formatter 互換の static HTML を生成する
 - `scripts/verify-pages.sh`
   - local で Pages build が成立するか検証する
 - `.github/workflows/verify.yml`
@@ -35,6 +35,18 @@
 - formatter shared asset と custom CSS / JS が配置される
 - author / canonical / Open Graph / Twitter Card / favicon metadata が出力される
 - 公開トップに operator wording (`Publishing Guide` / `canonical source`) が残っていない
+- checklist source、JA/EN counterpart、固定 route、sidebar、prev/next、troubleshooting flow の正契約と負契約
+
+## Reader Resources
+
+`scripts/build-pages.py` の `reader_resource_specs()` が、公開 route と source artifact の唯一の mapping を持つ。チェックリスト index はこの mapping から生成し、チェックリスト本文を別の Markdown へ複製しない。
+
+- 日本語: `/checklists/`、`/checklists/prompt-contract-review/`、`/checklists/verification/`、`/checklists/repo-hygiene/`、`/troubleshooting/`
+- English: `/en/checklists/`、`/en/checklists/prompt-contract-review/`、`/en/checklists/verification/`、`/en/checklists/repo-hygiene/`、`/en/troubleshooting/`
+
+チェックリスト個別ページは `checklists/` と `checklists/en/` の既存 artifact を直接 source とする。トラブルシューティングは `docs/troubleshooting.md` と `docs/en/troubleshooting.md` を source とし、症状、再現、最小安全確認、Prompt / Context / Harness、停止 / エスカレーション、証跡の順で安全優先に扱う。
+
+`./scripts/verify-book.sh` と `./scripts/verify-pages.sh` はともに `build-pages.py --verify-reader-resources` を実行する。この isolated negative regression は、JA/EN counterpart、route、navigation、checklist mapping、flow marker、duplicate route の欠落を拒否する。
 
 ## GitHub Actions
 
@@ -52,6 +64,10 @@
   - 日本語版の導入ページ
 - `/en/`
   - 英語版の導入ページ
+- `/checklists/` と `/troubleshooting/`
+  - 日本語版の reader resources
+- `/en/checklists/` と `/en/troubleshooting/`
+  - 英語版の reader resources
 - `/chapters/ch01/` 以降
   - 日本語版 chapter / appendix / backmatter
 - `/en/chapters/ch01/` 以降

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -46,6 +46,8 @@
 
 チェックリスト個別ページは `checklists/` と `checklists/en/` の既存 artifact を直接 source とする。トラブルシューティングは `docs/troubleshooting.md` と `docs/en/troubleshooting.md` を source とし、症状、再現、最小安全確認、Prompt / Context / Harness、停止 / エスカレーション、証跡の順で安全優先に扱う。
 
+reader resource の prev/next は5ページだけの独立系列とする。既存 manuscript / backmatter の系列には接続せず、従来どおり最終 backmatter を終端に保つ。
+
 `./scripts/verify-book.sh` と `./scripts/verify-pages.sh` はともに `build-pages.py --verify-reader-resources` を実行する。この isolated negative regression は、JA/EN counterpart、route、navigation、checklist mapping、flow marker、duplicate route の欠落を拒否する。
 
 ## GitHub Actions

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,52 @@
+# 安全優先トラブルシューティングフロー
+
+AI エージェントの作業が期待どおりに進まない場合は、速く直すことよりも、影響を広げずに原因と判断材料を残すことを優先する。この flow は Prompt、Context、Harness のどこで失敗が起きているかを、最小の安全な操作で切り分けるための reader-facing な手順である。
+
+## 0. 直ちに停止して保護する
+
+次のいずれかに当たる場合は、再試行や追加操作をせずに停止する。
+
+- production、顧客データ、認証情報、外部公開、課金、破壊的な command に影響する可能性がある
+- Permission Policy、Tool Contract、Approval Gate の境界が不明確である
+- 失敗の結果として、想定外のファイル変更、外部送信、権限昇格、データ欠損が観測された
+
+停止は失敗ではない。安全境界を保ったまま、次の担当者が判断できる状態にするための操作である。
+
+## 1. 症状を記録する
+
+最初に、期待した behavior と実際の症状を分けて記録する。task、run timestamp または run ID、入力、実行 command、error、変更されたファイル、外部操作の有無を残す。過去の log や trace を current-run verify の代替にしない。
+
+## 2. 再現を最小化する
+
+同じ症状を、読み取り専用または隔離された最小入力で再現する。再現しない場合は、入力、環境、権限、タイミングなど、元の run と異なる条件を明示する。再現のために production データや承認済みでない外部操作を使わない。
+
+## 3. 最小安全確認を行う
+
+変更を加える前に、対象 repo、branch、working tree、許可された tool / command、network access、approval の要否を確認する。安全な確認で scope を確定できない場合は、原因仮説を増やさずに停止する。
+
+## 4. Prompt を切り分ける
+
+Objective、Inputs、Constraints、Tool Contract、Completion Criteria、Refusal / Stop Conditions が observable な形でそろっているかを確認する。曖昧な要求、競合する制約、欠落した出力契約は Prompt 側の failure mode として扱う。Prompt を変更する場合も、最小の再現入力で expected output を先に定義する。
+
+## 5. Context を切り分ける
+
+必要な artifact、対象ファイル、用語、既存の decision、current state が context に入っているかを確認する。古い情報、無関係な大量入力、JA/EN counterpart の取り違え、絶対パスなどは Context 側の failure mode である。context を追加する前に、必要な source of truth を一つずつ特定する。
+
+## 6. Harness を切り分ける
+
+実行順序、tool permission、timeout、retry、verify command、CI との差分、evidence の保存を確認する。Prompt と Context が正しくても、Harness の境界や verify が欠けていれば安全に完了したとは判定しない。Harness の失敗は、再試行の回数ではなく command と結果で切り分ける。
+
+## 7. 停止とエスカレーションを判断する
+
+次の場合は停止し、適切な owner または approver へエスカレーションする。
+
+- 安全境界、Permission Policy、Approval Gate を越える判断が必要である
+- 最小再現で data loss、security、privacy、外部影響の可能性が残る
+- Prompt、Context、Harness のいずれにも単独で帰属できず、source of truth が衝突している
+- current-run の verify が実行できない、または failure mode を説明できない
+
+エスカレーションには、症状、再現条件、停止した理由、試した最小安全確認、必要な判断を添える。
+
+## 8. 証跡を残す
+
+Evidence / Approval には、実行 command、run timestamp または run ID、pass / fail、関連する diff、trace、redaction の要否、承認主体と判断材料を残す。証跡は次の再試行、review、handoff で同じ危険な操作を繰り返さないために必要である。

--- a/scripts/build-pages.py
+++ b/scripts/build-pages.py
@@ -645,7 +645,7 @@ def render_checklist_index(page: Page, pages: list[Page]) -> str:
         for checklist in checklist_pages
     )
     heading = "収録チェックリスト" if page.language == "ja" else "Included Checklists"
-    return f"<p>{html.escape(intro)}</p><h2>{heading}</h2><ul>{items}</ul>"
+    return f"<p>{html.escape(intro)}</p><h2>{html.escape(heading)}</h2><ul>{items}</ul>"
 
 
 def rendered_body(page: Page, pages: list[Page]) -> str:

--- a/scripts/build-pages.py
+++ b/scripts/build-pages.py
@@ -630,8 +630,8 @@ def render_pager(page: Page, previous_page: Page | None, next_page: Page | None)
 
 
 def render_checklist_index(page: Page, pages: list[Page]) -> str:
-    resources = {resource.logical_id: resource for resource in pages if resource.section_key == "reader-resources"}
-    checklist_pages = [resources[f"reader-resource:{resource_id}"] for resource_id in CHECKLIST_RESOURCE_IDS]
+    reader_pages = {candidate.logical_id: candidate for candidate in pages if candidate.section_key == "reader-resources"}
+    checklist_pages = [reader_pages[f"reader-resource:{resource_id}"] for resource_id in CHECKLIST_RESOURCE_IDS]
     intro = (
         "各チェックリストは repository 内の既存 artifact をそのまま公開している。"
         "この索引は本文を複製せず、用途に応じた artifact への導線だけを提供する。"

--- a/scripts/build-pages.py
+++ b/scripts/build-pages.py
@@ -1011,13 +1011,17 @@ def build_counterpart_map(books: dict[str, list[Page]]) -> dict[tuple[str, str],
     return lookup
 
 
-def pager_neighbors(pages: list[Page], page: Page) -> tuple[Page | None, Page | None]:
-    is_resource = page.section_key == "reader-resources"
-    sequence = [candidate for candidate in pages if (candidate.section_key == "reader-resources") == is_resource]
-    index = sequence.index(page)
-    previous_page = sequence[index - 1] if index > 0 else None
-    next_page = sequence[index + 1] if index < len(sequence) - 1 else None
-    return previous_page, next_page
+def build_pager_map(pages: list[Page]) -> dict[Path, tuple[Page | None, Page | None]]:
+    pager_map: dict[Path, tuple[Page | None, Page | None]] = {}
+    for is_resource in (False, True):
+        sequence = [page for page in pages if (page.section_key == "reader-resources") == is_resource]
+        for index, page in enumerate(sequence):
+            previous_page = sequence[index - 1] if index > 0 else None
+            next_page = sequence[index + 1] if index < len(sequence) - 1 else None
+            pager_map[page.output_rel] = (previous_page, next_page)
+    if len(pager_map) != len(pages):
+        raise ValueError("pager map requires unique generated page routes")
+    return pager_map
 
 
 def main() -> None:
@@ -1037,12 +1041,13 @@ def main() -> None:
     books = {language: collect_pages(language) for language in ("ja", "en")}
     validate_page_paths(books)
     lookup = build_counterpart_map(books)
+    pagers = {language: build_pager_map(pages) for language, pages in books.items()}
 
     for language, pages in books.items():
         for page in pages:
             other_language = "en" if language == "ja" else "ja"
             counterpart = lookup.get((other_language, page.logical_id))
-            previous_page, next_page = pager_neighbors(pages, page)
+            previous_page, next_page = pagers[language][page.output_rel]
             render_page(output_dir, pages, page, previous_page, next_page, counterpart)
 
     print(f"pages site built at {output_dir}")

--- a/scripts/build-pages.py
+++ b/scripts/build-pages.py
@@ -72,6 +72,50 @@ TROUBLESHOOTING_FLOW_MARKERS = {
     "ja": ("症状", "再現", "最小安全確認", "Prompt", "Context", "Harness", "停止", "エスカレーション", "証跡"),
     "en": ("Symptoms", "Reproduce", "Minimum Safe Check", "Prompt", "Context", "Harness", "Stop", "Escalate", "Evidence"),
 }
+TROUBLESHOOTING_FLOW_HEADINGS = {
+    "ja": (
+        "## 0. 直ちに停止して保護する",
+        "## 1. 症状を記録する",
+        "## 2. 再現を最小化する",
+        "## 3. 最小安全確認を行う",
+        "## 4. Prompt を切り分ける",
+        "## 5. Context を切り分ける",
+        "## 6. Harness を切り分ける",
+        "## 7. 停止とエスカレーションを判断する",
+        "## 8. 証跡を残す",
+    ),
+    "en": (
+        "## 0. Stop Immediately and Protect the Boundary",
+        "## 1. Record the Symptoms",
+        "## 2. Reproduce with the Smallest Input",
+        "## 3. Perform a Minimum Safe Check",
+        "## 4. Diagnose the Prompt",
+        "## 5. Diagnose the Context",
+        "## 6. Diagnose the Harness",
+        "## 7. Decide When to Stop and Escalate",
+        "## 8. Preserve Evidence",
+    ),
+}
+
+# Independent test oracle. Keep this literal separate from
+# reader_resource_specs() so the dependency-free verifier rejects accidental
+# changes to a route, navigation label, kind, or canonical source mapping.
+EXPECTED_READER_RESOURCE_CONTRACT = {
+    "ja": {
+        "checklists": ReaderResourceSpec("checklists", "checklists", None, "チェックリスト集", "checklist-index"),
+        "checklist:prompt-contract-review": ReaderResourceSpec("checklist:prompt-contract-review", "checklists/prompt-contract-review", "checklists/prompt-contract-review.md", "Prompt Contract Review Checklist", "checklist"),
+        "checklist:verification": ReaderResourceSpec("checklist:verification", "checklists/verification", "checklists/verification.md", "Verification Checklist", "checklist"),
+        "checklist:repo-hygiene": ReaderResourceSpec("checklist:repo-hygiene", "checklists/repo-hygiene", "checklists/repo-hygiene.md", "Repo Hygiene Checklist", "checklist"),
+        "troubleshooting": ReaderResourceSpec("troubleshooting", "troubleshooting", "docs/troubleshooting.md", "トラブルシューティング", "troubleshooting"),
+    },
+    "en": {
+        "checklists": ReaderResourceSpec("checklists", "checklists", None, "Checklists", "checklist-index"),
+        "checklist:prompt-contract-review": ReaderResourceSpec("checklist:prompt-contract-review", "checklists/prompt-contract-review", "checklists/en/prompt-contract-review.md", "Prompt Contract Review Checklist", "checklist"),
+        "checklist:verification": ReaderResourceSpec("checklist:verification", "checklists/verification", "checklists/en/verification.md", "Verification Checklist", "checklist"),
+        "checklist:repo-hygiene": ReaderResourceSpec("checklist:repo-hygiene", "checklists/repo-hygiene", "checklists/en/repo-hygiene.md", "Repo Hygiene Checklist", "checklist"),
+        "troubleshooting": ReaderResourceSpec("troubleshooting", "troubleshooting", "docs/en/troubleshooting.md", "Troubleshooting", "troubleshooting"),
+    },
+}
 
 
 BOOK_SPECS = {
@@ -788,13 +832,19 @@ def validate_troubleshooting_flow(language: str, text: str) -> None:
         raise ValueError(
             f"{language} troubleshooting flow is missing safety-first markers: {', '.join(missing)}"
         )
+    headings = TROUBLESHOOTING_FLOW_HEADINGS[language]
+    duplicate = [heading for heading in headings if text.count(heading) != 1]
+    if duplicate:
+        raise ValueError(
+            f"{language} troubleshooting flow heading must occur exactly once: {', '.join(duplicate)}"
+        )
+    positions = [text.index(heading) for heading in headings]
+    if positions != sorted(positions):
+        raise ValueError(f"{language} troubleshooting flow headings are out of order")
 
 
 def validate_reader_resource_specs(resources_by_language: dict[str, list[ReaderResourceSpec]]) -> None:
-    expected_by_language = {
-        language: {resource.logical_id: resource for resource in reader_resource_specs(language)}
-        for language in ("ja", "en")
-    }
+    expected_by_language = EXPECTED_READER_RESOURCE_CONTRACT
     actual_ids = {
         language: {resource.logical_id for resource in resources_by_language[language]}
         for language in ("ja", "en")
@@ -912,6 +962,14 @@ def run_reader_resource_negative_regressions() -> None:
             raise SystemExit(f"flow regression produced an unexpected error: {error}") from error
     else:
         raise SystemExit("flow regression was accepted")
+    out_of_order = "\n".join(reversed(TROUBLESHOOTING_FLOW_HEADINGS["ja"]))
+    try:
+        validate_troubleshooting_flow("ja", out_of_order)
+    except ValueError as error:
+        if "out of order" not in str(error):
+            raise SystemExit(f"flow order regression produced an unexpected error: {error}") from error
+    else:
+        raise SystemExit("flow order regression was accepted")
 
 
 def collect_pages(language: str) -> list[Page]:
@@ -953,6 +1011,15 @@ def build_counterpart_map(books: dict[str, list[Page]]) -> dict[tuple[str, str],
     return lookup
 
 
+def pager_neighbors(pages: list[Page], page: Page) -> tuple[Page | None, Page | None]:
+    is_resource = page.section_key == "reader-resources"
+    sequence = [candidate for candidate in pages if (candidate.section_key == "reader-resources") == is_resource]
+    index = sequence.index(page)
+    previous_page = sequence[index - 1] if index > 0 else None
+    next_page = sequence[index + 1] if index < len(sequence) - 1 else None
+    return previous_page, next_page
+
+
 def main() -> None:
     args = parse_args()
     reader_resources = {language: reader_resource_specs(language) for language in ("ja", "en")}
@@ -972,11 +1039,10 @@ def main() -> None:
     lookup = build_counterpart_map(books)
 
     for language, pages in books.items():
-        for index, page in enumerate(pages):
+        for page in pages:
             other_language = "en" if language == "ja" else "ja"
             counterpart = lookup.get((other_language, page.logical_id))
-            previous_page = pages[index - 1] if index > 0 else None
-            next_page = pages[index + 1] if index < len(pages) - 1 else None
+            previous_page, next_page = pager_neighbors(pages, page)
             render_page(output_dir, pages, page, previous_page, next_page, counterpart)
 
     print(f"pages site built at {output_dir}")

--- a/scripts/build-pages.py
+++ b/scripts/build-pages.py
@@ -6,7 +6,7 @@ import html
 import os
 import re
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import markdown
@@ -28,13 +28,22 @@ class SectionSpec:
     part: bool = False
 
 
+@dataclass(frozen=True)
+class ReaderResourceSpec:
+    logical_id: str
+    route: str
+    source_rel: str | None
+    nav_title: str
+    kind: str
+
+
 @dataclass
 class Page:
     language: str
     language_label: str
     lang_attr: str
     source_root: Path
-    source_path: Path
+    source_path: Path | None
     section_key: str
     section_title: str
     title: str
@@ -47,6 +56,25 @@ class Page:
     nav_title: str
     nav_group: str
     logical_id: str
+    resource_kind: str | None
+
+
+READER_RESOURCE_ROUTES = {
+    "checklists": "checklists",
+    "checklist:prompt-contract-review": "checklists/prompt-contract-review",
+    "checklist:verification": "checklists/verification",
+    "checklist:repo-hygiene": "checklists/repo-hygiene",
+    "troubleshooting": "troubleshooting",
+}
+CHECKLIST_RESOURCE_IDS = (
+    "checklist:prompt-contract-review",
+    "checklist:verification",
+    "checklist:repo-hygiene",
+)
+TROUBLESHOOTING_FLOW_MARKERS = {
+    "ja": ("症状", "再現", "最小安全確認", "Prompt", "Context", "Harness", "停止", "エスカレーション", "証跡"),
+    "en": ("Symptoms", "Reproduce", "Minimum Safe Check", "Prompt", "Context", "Harness", "Stop", "Escalate", "Evidence"),
+}
 
 
 BOOK_SPECS = {
@@ -121,6 +149,11 @@ def parse_args() -> argparse.Namespace:
         "--output",
         default=str(ROOT / "dist" / "pages"),
         help="Output directory for the built site.",
+    )
+    parser.add_argument(
+        "--verify-reader-resources",
+        action="store_true",
+        help="Run isolated reader-resource source, route, navigation, and negative-contract checks.",
     )
     return parser.parse_args()
 
@@ -198,6 +231,69 @@ def page_token(path: Path) -> str:
 
 def page_prefix(language: str) -> Path:
     return Path() if language == "ja" else Path("en")
+
+
+def reader_resource_specs(language: str) -> list[ReaderResourceSpec]:
+    if language == "ja":
+        labels = {
+            "checklists": "チェックリスト集",
+            "checklist:prompt-contract-review": "Prompt Contract Review Checklist",
+            "checklist:verification": "Verification Checklist",
+            "checklist:repo-hygiene": "Repo Hygiene Checklist",
+            "troubleshooting": "トラブルシューティング",
+        }
+        source_prefix = ""
+        troubleshooting_source = "docs/troubleshooting.md"
+    else:
+        labels = {
+            "checklists": "Checklists",
+            "checklist:prompt-contract-review": "Prompt Contract Review Checklist",
+            "checklist:verification": "Verification Checklist",
+            "checklist:repo-hygiene": "Repo Hygiene Checklist",
+            "troubleshooting": "Troubleshooting",
+        }
+        source_prefix = "en/"
+        troubleshooting_source = "docs/en/troubleshooting.md"
+
+    return [
+        ReaderResourceSpec("checklists", READER_RESOURCE_ROUTES["checklists"], None, labels["checklists"], "checklist-index"),
+        ReaderResourceSpec(
+            "checklist:prompt-contract-review",
+            READER_RESOURCE_ROUTES["checklist:prompt-contract-review"],
+            f"checklists/{source_prefix}prompt-contract-review.md",
+            labels["checklist:prompt-contract-review"],
+            "checklist",
+        ),
+        ReaderResourceSpec(
+            "checklist:verification",
+            READER_RESOURCE_ROUTES["checklist:verification"],
+            f"checklists/{source_prefix}verification.md",
+            labels["checklist:verification"],
+            "checklist",
+        ),
+        ReaderResourceSpec(
+            "checklist:repo-hygiene",
+            READER_RESOURCE_ROUTES["checklist:repo-hygiene"],
+            f"checklists/{source_prefix}repo-hygiene.md",
+            labels["checklist:repo-hygiene"],
+            "checklist",
+        ),
+        ReaderResourceSpec(
+            "troubleshooting",
+            READER_RESOURCE_ROUTES["troubleshooting"],
+            troubleshooting_source,
+            labels["troubleshooting"],
+            "troubleshooting",
+        ),
+    ]
+
+
+def reader_resource_group_title(language: str) -> str:
+    return "読者向けリソース" if language == "ja" else "Reader Resources"
+
+
+def reader_output_rel(language: str, route: str) -> Path:
+    return page_prefix(language) / route / "index.html"
 
 
 def output_rel(language: str, section: SectionSpec, source_path: Path) -> Path:
@@ -291,6 +387,51 @@ def load_page(language: str, section: SectionSpec, source_path: Path) -> Page:
         nav_title=nav_title_for(language, page_kind, page_label, title),
         nav_group=section.title,
         logical_id=f"{section.key}:{page_token(source_path)}",
+        resource_kind=None,
+    )
+
+
+def load_reader_resource_page(language: str, resource: ReaderResourceSpec) -> Page:
+    spec = BOOK_SPECS[language]
+    source_path = ROOT / resource.source_rel if resource.source_rel else None
+    if source_path:
+        raw = source_path.read_text(encoding="utf-8")
+        body = strip_frontmatter(raw).strip()
+        title = extract_title(body, resource.nav_title)
+        content_body = strip_leading_h1_markdown(body)
+        md = markdown.Markdown(extensions=["extra", "toc", "sane_lists"])
+        excerpt = extract_excerpt(body)
+        body_html = remove_duplicate_excerpt_paragraph(md.convert(content_body), excerpt)
+        toc_html = md.toc if md.toc else ""
+    else:
+        title = resource.nav_title
+        excerpt = (
+            "既存のチェックリスト artifact を用途別に読む。"
+            if language == "ja"
+            else "Read the existing checklist artifacts by use case."
+        )
+        body_html = ""
+        toc_html = ""
+
+    return Page(
+        language=language,
+        language_label=spec["label"],
+        lang_attr=spec["lang_attr"],
+        source_root=ROOT,
+        source_path=source_path,
+        section_key="reader-resources",
+        section_title=reader_resource_group_title(language),
+        title=title,
+        excerpt=excerpt,
+        output_rel=reader_output_rel(language, resource.route),
+        body_html=body_html,
+        toc_html=toc_html,
+        page_kind="reader-resource",
+        page_label=reader_resource_group_title(language),
+        nav_title=resource.nav_title,
+        nav_group=reader_resource_group_title(language),
+        logical_id=f"reader-resource:{resource.logical_id}",
+        resource_kind=resource.kind,
     )
 
 
@@ -441,6 +582,31 @@ def render_pager(page: Page, previous_page: Page | None, next_page: Page | None)
     )
 
 
+def render_checklist_index(page: Page, pages: list[Page]) -> str:
+    resources = {resource.logical_id: resource for resource in pages if resource.section_key == "reader-resources"}
+    checklist_pages = [resources[f"reader-resource:{resource_id}"] for resource_id in CHECKLIST_RESOURCE_IDS]
+    intro = (
+        "各チェックリストは repository 内の既存 artifact をそのまま公開している。"
+        "この索引は本文を複製せず、用途に応じた artifact への導線だけを提供する。"
+        if page.language == "ja"
+        else "Each checklist is published directly from its existing repository artifact. "
+        "This index does not duplicate checklist content; it only provides task-oriented routes to those artifacts."
+    )
+    items = "".join(
+        f"<li><a href=\"{html.escape(rel_link(page.output_rel, checklist.output_rel))}\">{html.escape(checklist.title)}</a>"
+        f"{f'<p>{html.escape(checklist.excerpt)}</p>' if checklist.excerpt else ''}</li>"
+        for checklist in checklist_pages
+    )
+    heading = "収録チェックリスト" if page.language == "ja" else "Included Checklists"
+    return f"<p>{html.escape(intro)}</p><h2>{heading}</h2><ul>{items}</ul>"
+
+
+def rendered_body(page: Page, pages: list[Page]) -> str:
+    if page.resource_kind == "checklist-index":
+        return render_checklist_index(page, pages)
+    return page.body_html
+
+
 def page_chrome(page: Page, body: str, current_search_placeholder: str) -> str:
     css_main = rel_link(page.output_rel, Path("assets") / "css" / "main.css")
     css_syntax = rel_link(page.output_rel, Path("assets") / "css" / "syntax-highlighting.css")
@@ -577,6 +743,11 @@ def render_page(
     spec = BOOK_SPECS[page.language]
     first_chapter = next(candidate for candidate in pages if candidate.page_kind == "chapter")
     sidebar_html = render_nav(pages, page, counterpart)
+    source_link = (
+        f"<a href=\"{html.escape(REPO_URL)}/blob/main/{html.escape(page.source_path.relative_to(ROOT).as_posix())}\" target=\"_blank\" rel=\"noopener\">Source Markdown</a>"
+        if page.source_path
+        else ""
+    )
     footer = (
         "<footer class=\"book-footer\" role=\"contentinfo\">"
         "<div class=\"book-footer-inner\">"
@@ -585,7 +756,7 @@ def render_page(
         "</div>"
         "<div class=\"book-footer-links\">"
         f"<a href=\"{html.escape(REPO_URL)}\" target=\"_blank\" rel=\"noopener\">GitHub</a>"
-        f"<a href=\"{html.escape(REPO_URL)}/blob/main/{html.escape(page.source_path.relative_to(ROOT).as_posix())}\" target=\"_blank\" rel=\"noopener\">Source Markdown</a>"
+        f"{source_link}"
         "</div>"
         "</div>"
         "</footer>"
@@ -596,7 +767,7 @@ def render_page(
         "<div class=\"book-content\">"
         "<article class=\"page-content\">"
         f"{render_lead(page, counterpart, first_chapter)}"
-        f"{page.body_html}"
+        f"{rendered_body(page, pages)}"
         "</article>"
         f"{render_pager(page, previous_page, next_page)}"
         f"{footer}"
@@ -608,12 +779,145 @@ def render_page(
     target.write_text(page_chrome(page, body, spec["search_placeholder"]), encoding="utf-8")
 
 
+def validate_troubleshooting_flow(language: str, text: str) -> None:
+    missing = [marker for marker in TROUBLESHOOTING_FLOW_MARKERS[language] if marker not in text]
+    if missing:
+        raise ValueError(
+            f"{language} troubleshooting flow is missing safety-first markers: {', '.join(missing)}"
+        )
+
+
+def validate_reader_resource_specs(resources_by_language: dict[str, list[ReaderResourceSpec]]) -> None:
+    expected_by_language = {
+        language: {resource.logical_id: resource for resource in reader_resource_specs(language)}
+        for language in ("ja", "en")
+    }
+    actual_ids = {
+        language: {resource.logical_id for resource in resources_by_language[language]}
+        for language in ("ja", "en")
+    }
+    if actual_ids["ja"] != actual_ids["en"]:
+        raise ValueError("reader resources have a missing JA/EN counterpart")
+
+    for language in ("ja", "en"):
+        resources = resources_by_language[language]
+        ids = [resource.logical_id for resource in resources]
+        if len(ids) != len(set(ids)):
+            raise ValueError(f"duplicate {language} reader-resource logical id")
+        routes = [resource.route for resource in resources]
+        if len(routes) != len(set(routes)):
+            raise ValueError(f"duplicate {language} reader-resource route")
+
+        expected = expected_by_language[language]
+        if set(ids) != set(expected):
+            missing_checklists = set(CHECKLIST_RESOURCE_IDS) - set(ids)
+            if missing_checklists:
+                raise ValueError(f"missing {language} checklist resource: {', '.join(sorted(missing_checklists))}")
+            raise ValueError(f"unexpected {language} reader-resource mapping")
+
+        for resource in resources:
+            canonical = expected[resource.logical_id]
+            if resource.route != canonical.route:
+                raise ValueError(f"invalid {language} reader-resource route for {resource.logical_id}")
+            if resource.nav_title != canonical.nav_title:
+                raise ValueError(f"invalid {language} reader-resource navigation for {resource.logical_id}")
+            if resource.kind != canonical.kind or resource.source_rel != canonical.source_rel:
+                raise ValueError(f"invalid {language} reader-resource source mapping for {resource.logical_id}")
+            if resource.source_rel is None:
+                continue
+            source_path = ROOT / resource.source_rel
+            if not source_path.is_file():
+                raise ValueError(f"missing {language} reader-resource source: {resource.source_rel}")
+            source_text = source_path.read_text(encoding="utf-8")
+            if not source_text.startswith("# "):
+                raise ValueError(f"invalid {language} reader-resource source heading: {resource.source_rel}")
+            if resource.kind == "troubleshooting":
+                validate_troubleshooting_flow(language, source_text)
+
+
+def validate_page_paths(books: dict[str, list[Page]]) -> None:
+    for language, pages in books.items():
+        routes = [page.output_rel.as_posix() for page in pages]
+        if len(routes) != len(set(routes)):
+            raise ValueError(f"duplicate {language} generated page route")
+
+
+def assert_reader_resource_failure(name: str, resources: dict[str, list[ReaderResourceSpec]], expected: str) -> None:
+    try:
+        validate_reader_resource_specs(resources)
+    except ValueError as error:
+        if expected not in str(error):
+            raise SystemExit(f"{name} regression produced an unexpected error: {error}") from error
+        return
+    raise SystemExit(f"{name} regression was accepted")
+
+
+def run_reader_resource_negative_regressions() -> None:
+    baseline = {language: reader_resource_specs(language) for language in ("ja", "en")}
+    assert_reader_resource_failure(
+        "missing counterpart",
+        {"ja": baseline["ja"], "en": [item for item in baseline["en"] if item.logical_id != "troubleshooting"]},
+        "missing JA/EN counterpart",
+    )
+    assert_reader_resource_failure(
+        "route",
+        {
+            "ja": [
+                replace(item, route="checklists/wrong-route") if item.logical_id == "checklists" else item
+                for item in baseline["ja"]
+            ],
+            "en": baseline["en"],
+        },
+        "invalid ja reader-resource route",
+    )
+    assert_reader_resource_failure(
+        "navigation",
+        {
+            "ja": [
+                replace(item, nav_title="Unexpected navigation") if item.logical_id == "checklists" else item
+                for item in baseline["ja"]
+            ],
+            "en": baseline["en"],
+        },
+        "invalid ja reader-resource navigation",
+    )
+    assert_reader_resource_failure(
+        "checklist",
+        {
+            language: [item for item in baseline[language] if item.logical_id != "checklist:verification"]
+            for language in ("ja", "en")
+        },
+        "missing ja checklist resource",
+    )
+    assert_reader_resource_failure(
+        "duplicate route",
+        {
+            "ja": [
+                replace(item, route=READER_RESOURCE_ROUTES["checklists"])
+                if item.logical_id == "troubleshooting"
+                else item
+                for item in baseline["ja"]
+            ],
+            "en": baseline["en"],
+        },
+        "duplicate ja reader-resource route",
+    )
+    try:
+        validate_troubleshooting_flow("ja", "症状\n再現\n最小安全確認\nPrompt\nContext\nHarness\n停止\nエスカレーション")
+    except ValueError as error:
+        if "証跡" not in str(error):
+            raise SystemExit(f"flow regression produced an unexpected error: {error}") from error
+    else:
+        raise SystemExit("flow regression was accepted")
+
+
 def collect_pages(language: str) -> list[Page]:
     spec = BOOK_SPECS[language]
     pages: list[Page] = []
     for section in spec["section_sequence"]:
         for source_path in ordered_section_paths(spec["root"], section):
             pages.append(load_page(language, section, source_path))
+    pages.extend(load_reader_resource_page(language, resource) for resource in reader_resource_specs(language))
     return pages
 
 
@@ -639,12 +943,21 @@ def build_counterpart_map(books: dict[str, list[Page]]) -> dict[tuple[str, str],
     lookup: dict[tuple[str, str], Page] = {}
     for language, pages in books.items():
         for page in pages:
-            lookup[(language, page.logical_id)] = page
+            key = (language, page.logical_id)
+            if key in lookup:
+                raise ValueError(f"duplicate {language} page logical id: {page.logical_id}")
+            lookup[key] = page
     return lookup
 
 
 def main() -> None:
     args = parse_args()
+    reader_resources = {language: reader_resource_specs(language) for language in ("ja", "en")}
+    validate_reader_resource_specs(reader_resources)
+    if args.verify_reader_resources:
+        run_reader_resource_negative_regressions()
+        print("reader-resource source and negative contracts look consistent")
+        return
     output_dir = Path(args.output).resolve()
     if output_dir.exists():
         shutil.rmtree(output_dir)
@@ -652,6 +965,7 @@ def main() -> None:
     copy_assets(output_dir)
 
     books = {language: collect_pages(language) for language in ("ja", "en")}
+    validate_page_paths(books)
     lookup = build_counterpart_map(books)
 
     for language, pages in books.items():

--- a/scripts/build-pages.py
+++ b/scripts/build-pages.py
@@ -9,9 +9,6 @@ import shutil
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-import markdown
-
-
 ROOT = Path(__file__).resolve().parents[1]
 REPO_URL = "https://github.com/itdojp/ai-agent-engineering-book"
 PAGES_BASE_URL = "https://itdojp.github.io/ai-agent-engineering-book"
@@ -194,6 +191,8 @@ def normalize_text(text: str) -> str:
 
 
 def normalize_markdown_text(text: str) -> str:
+    import markdown
+
     rendered_html = markdown.markdown(text, extensions=["extra", "sane_lists"])
     plain_text = re.sub(r"<[^>]+>", "", rendered_html)
     return normalize_text(plain_text)
@@ -360,6 +359,8 @@ def nav_title_for(language: str, page_kind: str, page_label: str, title: str) ->
 
 
 def load_page(language: str, section: SectionSpec, source_path: Path) -> Page:
+    import markdown
+
     spec = BOOK_SPECS[language]
     raw = source_path.read_text(encoding="utf-8")
     body = strip_frontmatter(raw).strip()
@@ -395,6 +396,8 @@ def load_reader_resource_page(language: str, resource: ReaderResourceSpec) -> Pa
     spec = BOOK_SPECS[language]
     source_path = ROOT / resource.source_rel if resource.source_rel else None
     if source_path:
+        import markdown
+
         raw = source_path.read_text(encoding="utf-8")
         body = strip_frontmatter(raw).strip()
         title = extract_title(body, resource.nav_title)

--- a/scripts/verify-book.sh
+++ b/scripts/verify-book.sh
@@ -82,7 +82,7 @@ for path in "${required[@]}"; do
 done
 
 python3 "$ROOT/scripts/run-prompt-evals.py"
-python3 "$ROOT/scripts/build-pages.py" --verify-reader-resources
+python3 -S "$ROOT/scripts/build-pages.py" --verify-reader-resources
 
 if [[ -n "$TARGET" ]]; then
   brief="$ROOT/manuscript/briefs/${TARGET}.yaml"

--- a/scripts/verify-book.sh
+++ b/scripts/verify-book.sh
@@ -9,6 +9,7 @@ required=(
   "README.md"
   "STATUS.md"
   "docs/pages-publishing.md"
+  "docs/troubleshooting.md"
   "artifacts/en/README.md"
   "artifacts/en/evidence/README.md"
   "docs/glossary.md"
@@ -20,6 +21,7 @@ required=(
   "docs/en/session-memory-policy.md"
   "docs/en/operating-model.md"
   "docs/en/metrics.md"
+  "docs/en/troubleshooting.md"
   "manuscript/AGENTS.md"
   "manuscript/front-matter/00-はじめに.md"
   "manuscript/front-matter/01-本書の読み方.md"
@@ -80,6 +82,7 @@ for path in "${required[@]}"; do
 done
 
 python3 "$ROOT/scripts/run-prompt-evals.py"
+python3 "$ROOT/scripts/build-pages.py" --verify-reader-resources
 
 if [[ -n "$TARGET" ]]; then
   brief="$ROOT/manuscript/briefs/${TARGET}.yaml"

--- a/scripts/verify-pages.sh
+++ b/scripts/verify-pages.sh
@@ -161,6 +161,12 @@ for language, group_title, index_title, counterpart_label in (
     require(out / verification, f'href="{href_to(verification, hygiene)}" class="nav-next"')
     require(out / hygiene, f'href="{href_to(hygiene, troubleshooting)}" class="nav-next"')
     require(out / troubleshooting, f'href="{href_to(troubleshooting, hygiene)}" class="nav-prev"')
+    require(out / first, '<span class="nav-disabled nav-prev">')
+
+    # Reader resources have their own pager sequence. Existing manuscript
+    # backmatter must remain terminal instead of acquiring a new next link.
+    terminal = prefix / Path("backmatter/03/index.html")
+    require(out / terminal, '<span class="nav-disabled nav-next">')
 
 print("reader resource routes, navigation, counterparts, and flow look consistent")
 PY

--- a/scripts/verify-pages.sh
+++ b/scripts/verify-pages.sh
@@ -15,6 +15,7 @@ python -m pip install --quiet --upgrade pip
 python -m pip install --quiet -r "$ROOT/requirements-pages.txt"
 
 OUT="$TMPDIR/site"
+python "$ROOT/scripts/build-pages.py" --verify-reader-resources
 python "$ROOT/scripts/build-pages.py" --output "$OUT"
 
 required=(
@@ -23,6 +24,16 @@ required=(
   "introduction/01/index.html"
   "chapters/ch01/index.html"
   "en/chapters/ch01/index.html"
+  "checklists/index.html"
+  "checklists/prompt-contract-review/index.html"
+  "checklists/verification/index.html"
+  "checklists/repo-hygiene/index.html"
+  "troubleshooting/index.html"
+  "en/checklists/index.html"
+  "en/checklists/prompt-contract-review/index.html"
+  "en/checklists/verification/index.html"
+  "en/checklists/repo-hygiene/index.html"
+  "en/troubleshooting/index.html"
   "assets/css/main.css"
   "assets/css/mobile-responsive.css"
   "assets/css/syntax-highlighting.css"
@@ -60,6 +71,15 @@ grep -q 'meta property="og:title"' "$OUT/en/index.html"
 grep -q 'meta property="og:site_name" content="AI Agent Engineering in Practice: Prompt / Context / Harness Engineering"' "$OUT/en/index.html"
 grep -q 'meta name="twitter:card" content="summary"' "$OUT/en/index.html"
 grep -q 'link rel="icon" type="image/svg+xml" href="../assets/images/favicon.svg"' "$OUT/en/index.html"
+grep -q 'Refusal / Stop Conditions' "$OUT/checklists/prompt-contract-review/index.html"
+grep -q 'Stop Instead Of Merge' "$OUT/checklists/verification/index.html"
+grep -q 'Escalate When' "$OUT/checklists/repo-hygiene/index.html"
+grep -q '最小安全確認' "$OUT/troubleshooting/index.html"
+grep -q '停止とエスカレーション' "$OUT/troubleshooting/index.html"
+grep -q '証跡を残す' "$OUT/troubleshooting/index.html"
+grep -q 'Minimum Safe Check' "$OUT/en/troubleshooting/index.html"
+grep -q 'Stop and Escalate' "$OUT/en/troubleshooting/index.html"
+grep -q 'Preserve Evidence' "$OUT/en/troubleshooting/index.html"
 
 if grep -q "AIエージェント実践" "$OUT/en/index.html" || \
    grep -q "AIエージェント実践" "$OUT/en/chapters/ch01/index.html"; then
@@ -82,5 +102,67 @@ if grep -q "canonical source" "$OUT/index.html"; then
   echo "public landing page still exposes canonical source wording"
   exit 1
 fi
+
+python3 - <<'PY' "$OUT"
+from pathlib import Path
+import posixpath
+import sys
+
+out = Path(sys.argv[1])
+routes = [
+    "checklists",
+    "checklists/prompt-contract-review",
+    "checklists/verification",
+    "checklists/repo-hygiene",
+    "troubleshooting",
+]
+
+def route_file(route: str) -> Path:
+    return Path(route) / "index.html"
+
+def href_to(source: Path, destination: Path) -> str:
+    return posixpath.relpath(destination.as_posix(), source.parent.as_posix())
+
+def require(path: Path, text: str) -> None:
+    content = path.read_text(encoding="utf-8")
+    if text not in content:
+        raise SystemExit(f"generated page {path.relative_to(out)} is missing: {text}")
+
+for language, group_title, index_title, counterpart_label in (
+    ("ja", "読者向けリソース", "チェックリスト集", "English"),
+    ("en", "Reader Resources", "Checklists", "日本語"),
+):
+    prefix = Path() if language == "ja" else Path("en")
+    counterpart_prefix = Path("en") if language == "ja" else Path()
+    for route in routes:
+        source = prefix / route_file(route)
+        counterpart = counterpart_prefix / route_file(route)
+        require(out / source, group_title)
+        require(out / source, counterpart_label)
+        require(out / source, f'href="{href_to(source, counterpart)}" class="external-link"')
+        for nav_route in routes:
+            destination = prefix / route_file(nav_route)
+            require(out / source, f'href="{href_to(source, destination)}" class="toc-link')
+
+    index = prefix / route_file("checklists")
+    require(out / index, index_title)
+    for checklist_route in routes[1:4]:
+        destination = prefix / route_file(checklist_route)
+        require(out / index, f'href="{href_to(index, destination)}"')
+
+    first = prefix / route_file("checklists")
+    prompt = prefix / route_file("checklists/prompt-contract-review")
+    verification = prefix / route_file("checklists/verification")
+    hygiene = prefix / route_file("checklists/repo-hygiene")
+    troubleshooting = prefix / route_file("troubleshooting")
+    require(out / first, f'href="{href_to(first, prompt)}" class="nav-next"')
+    require(out / prompt, f'href="{href_to(prompt, first)}" class="nav-prev"')
+    require(out / prompt, f'href="{href_to(prompt, verification)}" class="nav-next"')
+    require(out / verification, f'href="{href_to(verification, hygiene)}" class="nav-next"')
+    require(out / hygiene, f'href="{href_to(hygiene, troubleshooting)}" class="nav-next"')
+    require(out / troubleshooting, f'href="{href_to(troubleshooting, hygiene)}" class="nav-prev"')
+
+print("reader resource routes, navigation, counterparts, and flow look consistent")
+PY
 
 echo "pages artifacts look consistent"

--- a/scripts/verify-pages.sh
+++ b/scripts/verify-pages.sh
@@ -103,7 +103,7 @@ if grep -q "canonical source" "$OUT/index.html"; then
   exit 1
 fi
 
-python3 - <<'PY' "$OUT"
+python - <<'PY' "$OUT"
 from pathlib import Path
 import posixpath
 import sys


### PR DESCRIPTION
## 概要

日本語版・英語版の公開サイトに、既存artifactを正本とするチェックリスト集と、安全優先のトラブルシューティングを追加します。

Closes #251

## 変更内容

- JA `/checklists/`、3個別route、`/troubleshooting/` を追加
- EN `/en/checklists/`、3個別route、`/en/troubleshooting/` を追加
- 既存6 checklist artifactを直接sourceとし、本文の複製を回避
- `reader_resource_specs()` にroute/source/sidebar/counterpart/prev-next契約を集約
- Prompt / Context / Harnessの切り分け、停止、エスカレーション、証跡を含む日英troubleshootingを追加
- missing counterpart/route/navigation/checklist/flow/duplicate routeを拒否するnegative regressionを追加
- built HTMLのroute、sidebar、counterpart、prev/nextを検証

## 影響

既存manuscriptとsample repositoryの前提は変更しません。公開reader resourceだけを追加し、JA/EN parityをCIで固定します。

## 検証

- `python3 scripts/build-pages.py --verify-reader-resources`
- `./scripts/verify-book.sh`
- `./scripts/verify-pages.sh`
- 500x1000 viewportでJA checklist / EN troubleshootingを確認
- `git diff --check`
